### PR TITLE
fix: session handling — anonymous sessions, commenter identity, password reset tokens

### DIFF
--- a/app/controllers/Frontend/ArticleController.php
+++ b/app/controllers/Frontend/ArticleController.php
@@ -6,6 +6,7 @@ use App\Controllers\Frontend\BaseController;
 use App\Models\Post;
 use App\Models\Comments;
 use App\Helpers\SessionHelper;
+use App\Helpers\AuthHelper;
 
 /**
  * ArticleController gestisce la visualizzazione degli articoli pubblici
@@ -78,7 +79,7 @@ class ArticleController extends BaseController
 
         // Get current user info for comments
         $userId = SessionHelper::getValue('user_id');
-        $userDisplayName = SessionHelper::getValue('display_name') ?? SessionHelper::getValue('username');
+        $userDisplayName = AuthHelper::getCurrentUserDisplayName();
 
         $this->render('article', [
             'article' => $article,

--- a/app/controllers/Frontend/AuthController.php
+++ b/app/controllers/Frontend/AuthController.php
@@ -7,6 +7,7 @@ use App\Helpers\SessionHelper;
 use App\Controllers\Frontend\BaseController;
 use App\Helpers\LogHelper;
 use App\Models\User;
+use App\Models\PasswordReset;
 use App\Helpers\HookHelper;
 use App\Helpers\RequestHelper;
 use App\Helpers\CSRFHelper;
@@ -21,15 +22,18 @@ class AuthController extends BaseController
 {
     private $userModel;
 
+    private $passwordResetModel;
+
 
     /**
      * AuthController constructor.
-     * Initializes the user model.
+     * Initializes the user and password reset models.
      */
     public function __construct($params = [])
     {
         parent::__construct($params);
         $this->userModel = new User();
+        $this->passwordResetModel = new PasswordReset();
     }
 
 
@@ -394,11 +398,10 @@ class AuthController extends BaseController
                 $tokenHash = password_hash($token, PASSWORD_BCRYPT);
                 $expiresAt = date('Y-m-d H:i:s', time() + 3600); // 1 hour expiration
 
-                // Store reset token in database or session
-                // For this implementation, we'll use session storage
-                SessionHelper::setValue('password_reset_token_' . $user['id'], $tokenHash);
-                SessionHelper::setValue('password_reset_expires_' . $user['id'], $expiresAt);
-                SessionHelper::setValue('password_reset_email_' . $user['id'], $email);
+                // Persist the token: the emailed link has to work from a browser that
+                // never saw this session. Storing it here also supersedes any token
+                // the user requested earlier.
+                $this->passwordResetModel->create($user['id'], $tokenHash, $expiresAt);
 
                 // Fire password reset requested hook
                 HookHelper::doAction('password_reset_requested', $user, $token, RequestHelper::server('REMOTE_ADDR', 'unknown'));
@@ -501,32 +504,13 @@ class AuthController extends BaseController
                 return;
             }
 
-            // Verify token
-            $storedTokenHash = SessionHelper::getValue('password_reset_token_' . $user['id']);
-            $expiresAt = SessionHelper::getValue('password_reset_expires_' . $user['id']);
-            $storedEmail = SessionHelper::getValue('password_reset_email_' . $user['id']);
+            // Verify the token against the stored hash. findValidByToken() rejects
+            // tokens that are expired, already used, or belong to another user, so a
+            // single generic message covers every failure without leaking which.
+            $resetRecord = $this->passwordResetModel->findValidByToken($user['id'], $token);
 
-            if (!$storedTokenHash || !$expiresAt || $storedEmail !== $email) {
+            if (!$resetRecord) {
                 SessionHelper::setFlashMessage('Invalid or expired reset link.', 'error');
-                RedirectHelper::redirect('/auth/forgot-password');
-                return;
-            }
-
-            // Check if token expired
-            if (strtotime($expiresAt) < time()) {
-                // Clean up expired token
-                SessionHelper::removeValue('password_reset_token_' . $user['id']);
-                SessionHelper::removeValue('password_reset_expires_' . $user['id']);
-                SessionHelper::removeValue('password_reset_email_' . $user['id']);
-
-                SessionHelper::setFlashMessage('Reset link has expired. Please request a new one.', 'error');
-                RedirectHelper::redirect('/auth/forgot-password');
-                return;
-            }
-
-            // Verify token hash
-            if (!password_verify($token, $storedTokenHash)) {
-                SessionHelper::setFlashMessage('Invalid reset link.', 'error');
                 RedirectHelper::redirect('/auth/forgot-password');
                 return;
             }
@@ -538,10 +522,8 @@ class AuthController extends BaseController
                 ]);
 
                 if ($updateResult) {
-                    // Clean up token data
-                    SessionHelper::removeValue('password_reset_token_' . $user['id']);
-                    SessionHelper::removeValue('password_reset_expires_' . $user['id']);
-                    SessionHelper::removeValue('password_reset_email_' . $user['id']);
+                    // Burn the token so the link cannot be replayed
+                    $this->passwordResetModel->markUsed($resetRecord['id']);
 
                     // Fire password reset successful hook
                     HookHelper::doAction('password_reset_successful', $user, RequestHelper::server('REMOTE_ADDR', 'unknown'));

--- a/app/controllers/Frontend/CommentController.php
+++ b/app/controllers/Frontend/CommentController.php
@@ -5,6 +5,7 @@ namespace App\Controllers\Frontend;
 use App\Controllers\Frontend\BaseController;
 use App\Models\Comments;
 use App\Helpers\SessionHelper;
+use App\Helpers\AuthHelper;
 use App\Helpers\RedirectHelper;
 
 class CommentController extends BaseController
@@ -114,8 +115,8 @@ class CommentController extends BaseController
             if ($userId) {
                 $commentData['user_id'] = $userId;
                 // Get user info from session for logged users
-                $userDisplayName = SessionHelper::getValue('display_name') ?? SessionHelper::getValue('username') ?? 'Utente registrato';
-                $userEmail = SessionHelper::getValue('email');
+                $userDisplayName = AuthHelper::getCurrentUserDisplayName() ?? 'Utente registrato';
+                $userEmail = AuthHelper::getCurrentUserEmail();
 
                 $commentData['author_name'] = $userDisplayName;
                 if ($userEmail) {

--- a/app/controllers/Frontend/PageController.php
+++ b/app/controllers/Frontend/PageController.php
@@ -7,6 +7,7 @@ use App\Models\Page;
 use App\Models\Comments;
 use App\Helpers\SessionHelper;
 use App\Helpers\SeoHelper;
+use App\Helpers\AuthHelper;
 
 /**
  * PageController manages the display of public static pages
@@ -76,7 +77,7 @@ class PageController extends BaseController
 
         // Get current user info for comments
         $userId = SessionHelper::getValue('user_id');
-        $userDisplayName = SessionHelper::getValue('display_name') ?? SessionHelper::getValue('username');
+        $userDisplayName = AuthHelper::getCurrentUserDisplayName();
 
         $this->render('page', [
             'page' => $page,

--- a/app/helpers/AuthHelper.php
+++ b/app/helpers/AuthHelper.php
@@ -38,4 +38,28 @@ class AuthHelper
     {
         return SessionHelper::hasValue('user_id') ? SessionHelper::getValue('user_id') : null;
     }
+
+    /**
+     * Get the current user's display name, falling back to the username
+     *
+     * Reads the keys login writes ('user_display_name', 'user_username'), so
+     * callers do not have to remember the prefix.
+     *
+     * @return string|null
+     */
+    public static function getCurrentUserDisplayName()
+    {
+        return SessionHelper::getValue('user_display_name')
+            ?? SessionHelper::getValue('user_username');
+    }
+
+    /**
+     * Get the current user's email address
+     *
+     * @return string|null
+     */
+    public static function getCurrentUserEmail()
+    {
+        return SessionHelper::getValue('user_email');
+    }
 }

--- a/app/middlewares/AuthMiddleware.php
+++ b/app/middlewares/AuthMiddleware.php
@@ -22,9 +22,10 @@ class AuthMiddleware
      */
     public static function isAuthenticated()
     {
-        // Check if user session exists
+        // Check if user session exists. An anonymous visitor has no session to end:
+        // destroying it here would throw away the CSRF token, any flash message and
+        // the return URL that requireAuth() is about to store.
         if (!SessionHelper::hasValue('user_id') || !SessionHelper::hasValue('user_role')) {
-            self::logout();
             return false;
         }
 
@@ -73,6 +74,12 @@ class AuthMiddleware
     public static function requireAuth()
     {
         if (!self::isAuthenticated()) {
+            // A timed-out session has just been destroyed, so make sure a session is
+            // active before writing to it, otherwise the return URL goes nowhere.
+            if (session_status() !== PHP_SESSION_ACTIVE) {
+                session_start();
+            }
+
             // Store intended URL for redirect after login
             SessionHelper::setValue('redirect_after_login', RequestHelper::server('REQUEST_URI'));
 

--- a/app/models/PasswordReset.php
+++ b/app/models/PasswordReset.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Models;
+
+use App\Core\Model;
+use App\Core\HookSystem;
+
+/**
+ * PasswordReset Model
+ *
+ * Persists password reset tokens. The emailed link has to work from a browser
+ * that never saw the session which requested the reset, so the token hash and
+ * its expiry cannot live in that session.
+ *
+ * @package App\Models
+ */
+class PasswordReset extends Model
+{
+    protected $table = 'password_resets';
+
+    /**
+     * Constructor
+     *
+     * @param \PDO|null $pdo Optional connection, mainly for tests
+     */
+    public function __construct(\PDO $pdo = null)
+    {
+        if ($pdo === null) {
+            parent::__construct();
+            return;
+        }
+
+        // An injected connection skips the Database singleton entirely, which is
+        // what lets the model be exercised against an in-memory SQLite database.
+        $this->db = $pdo;
+        $this->hookSystem = HookSystem::getInstance();
+    }
+
+    /**
+     * Store a new reset token, superseding any token the user already has
+     *
+     * @param int $userId
+     * @param string $tokenHash Hash of the token, never the token itself
+     * @param string $expiresAt 'Y-m-d H:i:s'
+     * @return bool
+     */
+    public function create($userId, $tokenHash, $expiresAt)
+    {
+        $this->deleteForUser($userId);
+
+        $stmt = $this->db->prepare(
+            "INSERT INTO {$this->table} (user_id, token_hash, expires_at)
+             VALUES (:user_id, :token_hash, :expires_at)"
+        );
+
+        return $stmt->execute([
+            'user_id' => $userId,
+            'token_hash' => $tokenHash,
+            'expires_at' => $expiresAt
+        ]);
+    }
+
+    /**
+     * Find the user's unused, unexpired token matching the given plaintext token
+     *
+     * @param int $userId
+     * @param string $token Plaintext token from the reset link
+     * @return array|null The row, or null when nothing matches
+     */
+    public function findValidByToken($userId, $token)
+    {
+        $stmt = $this->db->prepare(
+            "SELECT * FROM {$this->table}
+             WHERE user_id = :user_id AND used_at IS NULL AND expires_at > :now
+             ORDER BY id DESC"
+        );
+        $stmt->execute([
+            'user_id' => $userId,
+            'now' => date('Y-m-d H:i:s')
+        ]);
+
+        foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+            if (password_verify($token, $row['token_hash'])) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Mark a token as used so it cannot be replayed
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function markUsed($id)
+    {
+        $stmt = $this->db->prepare(
+            "UPDATE {$this->table} SET used_at = :used_at WHERE id = :id"
+        );
+
+        return $stmt->execute([
+            'used_at' => date('Y-m-d H:i:s'),
+            'id' => $id
+        ]);
+    }
+
+    /**
+     * Delete every token belonging to a user
+     *
+     * @param int $userId
+     * @return bool
+     */
+    public function deleteForUser($userId)
+    {
+        $stmt = $this->db->prepare("DELETE FROM {$this->table} WHERE user_id = :user_id");
+
+        return $stmt->execute(['user_id' => $userId]);
+    }
+
+    /**
+     * Delete tokens that are past their expiry
+     *
+     * @return bool
+     */
+    public function deleteExpired()
+    {
+        $stmt = $this->db->prepare("DELETE FROM {$this->table} WHERE expires_at <= :now");
+
+        return $stmt->execute(['now' => date('Y-m-d H:i:s')]);
+    }
+}

--- a/database/migrations/2026_08_28_000001_create_password_resets_table.php
+++ b/database/migrations/2026_08_28_000001_create_password_resets_table.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/../../app/core/Database/Migration.php';
+
+use App\Core\Database\Database;
+use App\Core\Database\Migration;
+
+/**
+ * Migration for creating password_resets table
+ * Reset tokens have to outlive the session that requested them, so they are
+ * persisted here instead of in the requesting browser's session.
+ * @property \PDO $db
+ */
+class CreatePasswordResetsTable extends Migration
+{
+    /**
+     * @var \PDO
+     */
+    protected $db;
+
+    public function __construct(\PDO $pdo = null)
+    {
+        parent::__construct($pdo);
+    }
+
+    /**
+     * Create the password_resets table compatible with MySQL and SQLite
+     */
+    public function up()
+    {
+        try {
+            $this->db->beginTransaction();
+            if (defined('DB_DRIVER') && DB_DRIVER === 'sqlite') {
+                $this->db->exec("CREATE TABLE IF NOT EXISTS password_resets (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    token_hash VARCHAR(255) NOT NULL,
+                    expires_at TIMESTAMP NOT NULL,
+                    used_at TIMESTAMP DEFAULT NULL,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );");
+                $this->db->exec("CREATE INDEX IF NOT EXISTS idx_password_resets_user ON password_resets(user_id);");
+                $this->db->exec("CREATE INDEX IF NOT EXISTS idx_password_resets_expires ON password_resets(expires_at);");
+            } else {
+                $this->db->exec("CREATE TABLE IF NOT EXISTS password_resets (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    user_id INT NOT NULL,
+                    token_hash VARCHAR(255) NOT NULL,
+                    expires_at TIMESTAMP NOT NULL,
+                    used_at TIMESTAMP NULL DEFAULT NULL,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    KEY idx_password_resets_user (user_id),
+                    KEY idx_password_resets_expires (expires_at)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+            }
+            if ($this->db->inTransaction()) {
+                $this->db->commit();
+            }
+        } catch (\PDOException $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Drop the password_resets table
+     */
+    public function down()
+    {
+        try {
+            $this->db->beginTransaction();
+            $this->db->exec("DROP TABLE IF EXISTS password_resets;");
+            if ($this->db->inTransaction()) {
+                $this->db->commit();
+            }
+        } catch (\PDOException $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
+        }
+    }
+}

--- a/tests/Unit/Helpers/AuthHelperTest.php
+++ b/tests/Unit/Helpers/AuthHelperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use App\Helpers\AuthHelper;
+use App\Helpers\SessionHelper;
+
+/**
+ * AuthHelper Test
+ * Tests reading the current user's identity from the session
+ *
+ * @package Tests\Unit\Helpers
+ */
+class AuthHelperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // SessionHelper reads and writes $_SESSION directly, so no session
+        // needs to be started for these tests.
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
+    public function testGetCurrentUserDisplayNameReturnsDisplayName()
+    {
+        SessionHelper::setValue('user_display_name', 'Jean-Marie');
+        SessionHelper::setValue('user_username', 'jm');
+
+        $this->assertEquals('Jean-Marie', AuthHelper::getCurrentUserDisplayName());
+    }
+
+    public function testGetCurrentUserDisplayNameFallsBackToUsername()
+    {
+        SessionHelper::setValue('user_username', 'jm');
+
+        $this->assertEquals('jm', AuthHelper::getCurrentUserDisplayName());
+    }
+
+    public function testGetCurrentUserDisplayNameReturnsNullWhenAnonymous()
+    {
+        $this->assertNull(AuthHelper::getCurrentUserDisplayName());
+    }
+
+    public function testGetCurrentUserEmailReturnsEmail()
+    {
+        SessionHelper::setValue('user_email', 'jm@example.com');
+
+        $this->assertEquals('jm@example.com', AuthHelper::getCurrentUserEmail());
+    }
+
+    public function testGetCurrentUserEmailReturnsNullWhenAnonymous()
+    {
+        $this->assertNull(AuthHelper::getCurrentUserEmail());
+    }
+
+    public function testIdentityUsesTheKeysLoginWrites()
+    {
+        // Exactly the keys AuthController writes on successful login
+        SessionHelper::setValue('user_id', 7);
+        SessionHelper::setValue('user_email', 'jm@example.com');
+        SessionHelper::setValue('user_username', 'jm');
+        SessionHelper::setValue('user_display_name', 'Jean-Marie');
+        SessionHelper::setValue('user_role', 'admin');
+
+        $this->assertEquals(7, AuthHelper::getCurrentUserId());
+        $this->assertEquals('Jean-Marie', AuthHelper::getCurrentUserDisplayName());
+        $this->assertEquals('jm@example.com', AuthHelper::getCurrentUserEmail());
+    }
+}

--- a/tests/Unit/Middlewares/AuthMiddlewareTest.php
+++ b/tests/Unit/Middlewares/AuthMiddlewareTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Middlewares;
+
+use PHPUnit\Framework\TestCase;
+use App\Middlewares\AuthMiddleware;
+use App\Helpers\SessionHelper;
+
+/**
+ * AuthMiddleware Test
+ * Tests session handling for anonymous visitors
+ *
+ * @package Tests\Unit\Middlewares
+ */
+class AuthMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testAnonymousVisitorIsNotAuthenticated()
+    {
+        $this->assertFalse(AuthMiddleware::isAuthenticated());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testAnonymousVisitorKeepsCsrfToken()
+    {
+        SessionHelper::setValue('csrf_token', 'token-value');
+
+        AuthMiddleware::isAuthenticated();
+
+        $this->assertEquals('token-value', SessionHelper::getValue('csrf_token'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testAnonymousVisitorKeepsFlashMessage()
+    {
+        SessionHelper::setFlashMessage('Please log in', 'info');
+
+        AuthMiddleware::isAuthenticated();
+
+        $this->assertTrue(SessionHelper::hasFlashMessage());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testSessionStaysActiveForAnonymousVisitor()
+    {
+        AuthMiddleware::isAuthenticated();
+
+        // The session must survive so that requireAuth() can store the
+        // return URL the visitor is about to be redirected away from.
+        $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
+
+        SessionHelper::setValue('redirect_after_login', '/admin/articles');
+        $this->assertEquals('/admin/articles', SessionHelper::getValue('redirect_after_login'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testPartialSessionIsNotTreatedAsAuthenticated()
+    {
+        // user_id without user_role must not pass the check
+        SessionHelper::setValue('user_id', 1);
+
+        $this->assertFalse(AuthMiddleware::isAuthenticated());
+    }
+}

--- a/tests/Unit/Models/PasswordResetTest.php
+++ b/tests/Unit/Models/PasswordResetTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use PHPUnit\Framework\TestCase;
+use App\Models\PasswordReset;
+
+// Composer autoloads app/ through a classmap, so a model added after the last
+// `composer dump-autoload` is invisible to the test run. The application itself
+// resolves it through App\Core\Autoloader's PSR-4 lookup.
+require_once dirname(__DIR__, 3) . '/app/models/PasswordReset.php';
+
+/**
+ * PasswordReset Test
+ * Reset tokens must survive the session that requested them, so they live in
+ * the database. These tests run against an in-memory SQLite database.
+ *
+ * @package Tests\Unit\Models
+ */
+class PasswordResetTest extends TestCase
+{
+    /** @var \PDO */
+    private $pdo;
+
+    /** @var PasswordReset */
+    private $model;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pdo = new \PDO('sqlite::memory:');
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC);
+        $this->pdo->exec("CREATE TABLE password_resets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token_hash VARCHAR(255) NOT NULL,
+            expires_at TIMESTAMP NOT NULL,
+            used_at TIMESTAMP DEFAULT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )");
+
+        $this->model = new PasswordReset($this->pdo);
+    }
+
+    private function futureDate(): string
+    {
+        return date('Y-m-d H:i:s', time() + 3600);
+    }
+
+    private function pastDate(): string
+    {
+        return date('Y-m-d H:i:s', time() - 60);
+    }
+
+    public function testCreateStoresTheTokenHash()
+    {
+        $hash = password_hash('token-abc', PASSWORD_BCRYPT);
+
+        $this->assertTrue($this->model->create(7, $hash, $this->futureDate()));
+
+        $rows = $this->pdo->query("SELECT * FROM password_resets")->fetchAll();
+        $this->assertCount(1, $rows);
+        $this->assertEquals(7, $rows[0]['user_id']);
+        $this->assertEquals($hash, $rows[0]['token_hash']);
+        $this->assertNull($rows[0]['used_at']);
+    }
+
+    public function testCreateInvalidatesPreviousTokensForTheSameUser()
+    {
+        $this->model->create(7, password_hash('first', PASSWORD_BCRYPT), $this->futureDate());
+        $this->model->create(7, password_hash('second', PASSWORD_BCRYPT), $this->futureDate());
+
+        $rows = $this->pdo->query("SELECT * FROM password_resets WHERE user_id = 7")->fetchAll();
+        $this->assertCount(1, $rows, 'Requesting a new reset must supersede the previous token');
+        $this->assertTrue(password_verify('second', $rows[0]['token_hash']));
+    }
+
+    public function testCreateLeavesOtherUsersTokensAlone()
+    {
+        $this->model->create(7, password_hash('seven', PASSWORD_BCRYPT), $this->futureDate());
+        $this->model->create(8, password_hash('eight', PASSWORD_BCRYPT), $this->futureDate());
+
+        $this->assertNotNull($this->model->findValidByToken(7, 'seven'));
+        $this->assertNotNull($this->model->findValidByToken(8, 'eight'));
+    }
+
+    public function testFindValidByTokenMatchesTheToken()
+    {
+        $this->model->create(7, password_hash('token-abc', PASSWORD_BCRYPT), $this->futureDate());
+
+        $row = $this->model->findValidByToken(7, 'token-abc');
+
+        $this->assertIsArray($row);
+        $this->assertEquals(7, $row['user_id']);
+    }
+
+    public function testFindValidByTokenRejectsAWrongToken()
+    {
+        $this->model->create(7, password_hash('token-abc', PASSWORD_BCRYPT), $this->futureDate());
+
+        $this->assertNull($this->model->findValidByToken(7, 'token-xyz'));
+    }
+
+    public function testFindValidByTokenRejectsAnotherUsersToken()
+    {
+        $this->model->create(7, password_hash('token-abc', PASSWORD_BCRYPT), $this->futureDate());
+
+        $this->assertNull($this->model->findValidByToken(8, 'token-abc'));
+    }
+
+    public function testFindValidByTokenRejectsAnExpiredToken()
+    {
+        $this->model->create(7, password_hash('token-abc', PASSWORD_BCRYPT), $this->pastDate());
+
+        $this->assertNull($this->model->findValidByToken(7, 'token-abc'));
+    }
+
+    public function testFindValidByTokenRejectsAnAlreadyUsedToken()
+    {
+        $this->model->create(7, password_hash('token-abc', PASSWORD_BCRYPT), $this->futureDate());
+        $row = $this->model->findValidByToken(7, 'token-abc');
+        $this->model->markUsed($row['id']);
+
+        $this->assertNull($this->model->findValidByToken(7, 'token-abc'));
+    }
+
+    public function testTokenSurvivesADifferentSession()
+    {
+        // The whole point of #7: a token created in one request must still be
+        // usable from a browser that never saw the session that created it.
+        $this->model->create(7, password_hash('token-abc', PASSWORD_BCRYPT), $this->futureDate());
+
+        $_SESSION = [];
+        $otherModel = new PasswordReset($this->pdo);
+
+        $this->assertIsArray($otherModel->findValidByToken(7, 'token-abc'));
+    }
+
+    public function testDeleteExpiredRemovesOnlyStaleRows()
+    {
+        $this->model->create(7, password_hash('fresh', PASSWORD_BCRYPT), $this->futureDate());
+        $this->pdo->exec("INSERT INTO password_resets (user_id, token_hash, expires_at)
+            VALUES (8, 'stale', '" . $this->pastDate() . "')");
+
+        $this->model->deleteExpired();
+
+        $rows = $this->pdo->query("SELECT user_id FROM password_resets")->fetchAll();
+        $this->assertCount(1, $rows);
+        $this->assertEquals(7, $rows[0]['user_id']);
+    }
+}


### PR DESCRIPTION
Closes #5, closes #6, closes #7

Batch 2 of the issue triage: the three session bugs, fixed in one branch because they are the same underlying problem — session state written in one place and read (or destroyed) in another. One commit per issue.

## #5 — `isAuthenticated()` destroyed anonymous visitors' sessions

`AuthMiddleware::isAuthenticated()` called `logout()` whenever it found no logged-in user. An anonymous visitor has no session to end, so this destroyed the session it had just been given, taking the CSRF token and any pending flash message with it. `requireAuth()` then wrote the return URL into that destroyed session, so the post-login redirect never survived and every visitor landed on `/admin`.

The missing-user branch now returns `false` without touching the session. The timeout branch still logs out — there a real session exists and ending it is the point — and `requireAuth()` starts a fresh session before storing the return URL, so that path keeps working too.

## #6 — commenter identity read from keys login never writes

`CommentController` looked up `display_name`, `username` and `email`; login writes `user_display_name`, `user_username` and `user_email`. Both lookups missed, so every comment from a logged-in user was stored as `Utente registrato` with no email. `PageController` and `ArticleController` read the same wrong keys.

Rather than patching the four call sites, the lookups moved onto `AuthHelper` beside the existing `getCurrentUserId()`. Callers no longer repeat the key names, so the drift cannot silently come back.

## #7 — password reset tokens lived in the requesting session

The token hash, expiry and target email were stored in the requesting browser's session, so the emailed link only worked inside that same session: request on a phone, open on a laptop, and the token could not be found. The same happened whenever the session expired inside the token's one-hour lifetime.

Tokens now live in a new `password_resets` table (`user_id`, token hash, `expires_at`, `used_at`), added by `database/migrations/2026_08_28_000001_create_password_resets_table.php` with both the SQLite and MySQL variants the other migrations carry. Requesting a reset supersedes the user's previous token, and a successful reset marks the row used so the link cannot be replayed. `findValidByToken()` rejects expired, used and foreign tokens alike, so the controller still answers every failure with one generic message and leaks nothing.

`PasswordReset` takes an optional PDO — the same pattern the `Migration` classes already use — so the model is testable against in-memory SQLite without the `Database` singleton.

## Testing

- `tests/Unit/Middlewares/AuthMiddlewareTest.php` (5 tests) — written first, 3 failed against the old code exactly as #5 describes: CSRF token gone, flash message gone, session status `NONE` instead of `ACTIVE`.
- `tests/Unit/Helpers/AuthHelperTest.php` (6 tests), including one that seeds precisely the keys `AuthController` writes on login and asserts the accessors find them.
- `tests/Unit/Models/PasswordResetTest.php` (10 tests) against in-memory SQLite: token matching, wrong token, another user's token, expired, already used, supersession of the previous token, and a test that a token created in one "session" is still found from another — the actual bug in #7.

`tests/Unit`: 208 tests, 23 errors — the same 23 present on `main` (missing MySQL and unwritable `logs/` on this host, `vendor/` is owned by `www-data` from the container). `phpcs --standard=PSR12` reports nothing on the new and changed files.

## Notes for the reviewer

- Reset **rate limiting** still counts attempts in the session, so clearing cookies resets the counter. Untouched here — it is a distinct weakness from the token storage this PR is about, and worth its own issue.
- Mail delivery remains unimplemented (the `TODO` in `requestPasswordResetAction` is unchanged); this PR only makes the token valid once a mailer exists.
- `tests/Unit/Models/PasswordResetTest.php` `require_once`s the model: Composer autoloads `app/` through a classmap, so a newly added model is invisible to the test run until `composer dump-autoload` runs, and `vendor/` is not writable from the host here. The application itself resolves the class through `App\Core\Autoloader`'s PSR-4 lookup, which I verified.
- Running the whole `tests/Integration` directory produces 40 errors, all `session_start(): Session cannot be started after headers have already been sent` — cross-test pollution that predates this branch (those tests lack `@runInSeparateProcess`). `PasswordResetFlowTest` and `PasswordResetRateLimitTest` pass when run on their own.
- The migration needs applying on existing installs: `php database/migrate.php up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)