### PR TITLE
fix: cache correctness — per-URL page cache keys and an explicit Cache-Control policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,10 @@ THUMBNAIL_SIZE=150
 TEMPLATE_CACHE=true
 TEMPLATE_CACHE_LIFETIME=3600
 
-# Page Cache
+# Page Cache (Smarty full-page cache)
+# Keep this off unless the theme templates wrap the CSRF token and the flash
+# messages in {nocache}: a cached page otherwise serves whatever the first
+# visitor saw, token included, to everyone else until it expires.
 PAGE_CACHE=false
 PAGE_CACHE_LIFETIME=1800
 

--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -65,3 +65,9 @@ ini_set('session.cookie_secure', 0); // Set to 1 if using HTTPS
 define('CACHE_DRIVER', env('CACHE_DRIVER', 'file')); // file or database
 define('CACHE_TTL', env('CACHE_TTL', 3600)); // Default TTL in seconds (1 hour)
 define('CACHE_PATH', ROOT_PATH . '/storage/cache');
+
+// Smarty full-page cache. Off by default: a cached page keeps the CSRF token
+// and flash messages of whoever rendered it first, so it is only safe once the
+// templates wrap those regions in {nocache}.
+define('PAGE_CACHE', filter_var(env('PAGE_CACHE', false), FILTER_VALIDATE_BOOLEAN));
+define('PAGE_CACHE_LIFETIME', (int) env('PAGE_CACHE_LIFETIME', 1800));

--- a/app/core/View.php
+++ b/app/core/View.php
@@ -6,6 +6,7 @@ use App\Helpers\LogHelper;
 use Smarty\Smarty;
 use App\Helpers\SessionHelper;
 use App\Helpers\SystemSettingsHelper;
+use App\Helpers\RequestHelper;
 use App\Core\HookSystem;
 
 /**
@@ -249,7 +250,7 @@ class View
 
                 // Get template content and allow plugins to modify it
                 ob_start();
-                $this->smarty->display($template . '.tpl');
+                $this->smarty->display($template . '.tpl', self::cacheIdForRequest());
                 $content = ob_get_clean();
 
                 // Apply content filters
@@ -416,6 +417,32 @@ class View
     }
 
     /**
+     * Build the Smarty cache id for the current request
+     *
+     * Smarty keys a cached page by template name alone, so without this every
+     * URL rendered through the same template would share a single cached page.
+     *
+     * @param string|null $uri Request URI, defaults to the current one
+     * @return string
+     */
+    public static function cacheIdForRequest($uri = null)
+    {
+        if ($uri === null) {
+            $uri = RequestHelper::server('REQUEST_URI', '/');
+        }
+
+        $path = parse_url($uri, PHP_URL_PATH);
+        $query = parse_url($uri, PHP_URL_QUERY);
+
+        $key = ($path === null || $path === false ? '/' : $path)
+            . ($query === null || $query === false ? '' : '?' . $query);
+
+        // Hashed so the id never contains '|', which Smarty reads as the cache
+        // group separator, nor anything else awkward in a cache filename.
+        return sha1($key);
+    }
+
+    /**
      * Configure caching settings based on environment
      */
     private function configureCaching()
@@ -426,11 +453,25 @@ class View
             $this->smarty->caching = Smarty::CACHING_OFF;
             $this->smarty->force_compile = true;
             $this->smarty->compile_check = true;
-        } else {
-            $this->smarty->caching = Smarty::CACHING_LIFETIME_CURRENT;
-            $this->smarty->cache_lifetime = 3600;
-            $this->smarty->compile_check = false;
+            return;
         }
+
+        $this->smarty->compile_check = false;
+
+        // Full-page caching is opt-in through PAGE_CACHE, which .env.example has
+        // always defaulted to false. It bakes whatever the first visitor saw into
+        // the page every later visitor gets, and the frontend templates embed the
+        // CSRF token and flash messages, so it is only safe once those regions are
+        // wrapped in {nocache}.
+        $pageCache = defined('PAGE_CACHE') ? PAGE_CACHE : false;
+
+        if (!$pageCache) {
+            $this->smarty->caching = Smarty::CACHING_OFF;
+            return;
+        }
+
+        $this->smarty->caching = Smarty::CACHING_LIFETIME_CURRENT;
+        $this->smarty->cache_lifetime = defined('PAGE_CACHE_LIFETIME') ? (int) PAGE_CACHE_LIFETIME : 1800;
     }
 
     /**

--- a/app/helpers/CacheHeaderHelper.php
+++ b/app/helpers/CacheHeaderHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * CacheHeaderHelper
+ *
+ * Decides the Cache-Control policy for a response. PHP's session cache limiter
+ * would otherwise stamp no-store, plus its 1981 Expires sentinel, on every
+ * request that starts a session — which here means every request the CMS serves.
+ */
+class CacheHeaderHelper
+{
+    /**
+     * Policy for authenticated areas: nothing may be written to disk or reused
+     * from the back/forward cache once the user logs out.
+     */
+    public const PRIVATE_NO_STORE = 'no-store, no-cache, must-revalidate';
+
+    /**
+     * Policy for the public side: the browser may reuse the page (so the Back
+     * button does not refetch), but shared caches may not hold it, because a
+     * rendered page embeds the CSRF token and, when logged in, the user's name.
+     */
+    public const PRIVATE_REVALIDATE = 'private, max-age=0, must-revalidate';
+
+    /**
+     * Path prefixes that must never be cached
+     *
+     * @var string[]
+     */
+    private const UNCACHEABLE_PREFIXES = ['/admin', '/auth'];
+
+    /**
+     * Get the Cache-Control value for a request path
+     *
+     * @param string $path Request path, with or without a query string
+     * @return string
+     */
+    public static function policyForPath($path)
+    {
+        $path = (string) $path;
+        $parsedPath = parse_url($path, PHP_URL_PATH);
+
+        if ($parsedPath === false || $parsedPath === null || $parsedPath === '') {
+            $parsedPath = '/';
+        }
+
+        foreach (self::UNCACHEABLE_PREFIXES as $prefix) {
+            if ($parsedPath === $prefix || strpos($parsedPath, $prefix . '/') === 0) {
+                return self::PRIVATE_NO_STORE;
+            }
+        }
+
+        return self::PRIVATE_REVALIDATE;
+    }
+
+    /**
+     * Get the Cache-Control value for the current request
+     *
+     * @return string
+     */
+    public static function policyForCurrentRequest()
+    {
+        return self::policyForPath($_SERVER['REQUEST_URI'] ?? '/');
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@
  */
 
 use App\Core\Autoloader;
+use App\Helpers\CacheHeaderHelper;
 use App\Controllers\InstallController;
 use App\Core\ErrorHandler;
 use App\Helpers\LogHelper;
@@ -95,7 +96,14 @@ if ($isHttps) {
     ini_set('session.cookie_secure', 1);
 }
 
-// Initialize session with secure settings
+// Initialize session with secure settings.
+// PHP's default cache limiter ('nocache') stamps no-store, Pragma: no-cache and
+// its 1981 Expires sentinel on every request that starts a session — which here
+// is every request the CMS serves. That is right for the admin panel, but on the
+// public side it stops the browser reusing anything and disables the
+// back/forward cache. State the policy per area instead.
+session_cache_limiter('');
+header('Cache-Control: ' . CacheHeaderHelper::policyForCurrentRequest());
 session_start();
 
 // Initialize CSRF token if it doesn't exist

--- a/tests/Unit/Cache/ViewCacheIdTest.php
+++ b/tests/Unit/Cache/ViewCacheIdTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Cache;
+
+use PHPUnit\Framework\TestCase;
+use App\Core\View;
+
+/**
+ * View cache id Test
+ * Smarty keys a cached page by template name alone, so without a cache id
+ * every URL rendered through the same template shares one cached page.
+ *
+ * @package Tests\Unit\Cache
+ */
+class ViewCacheIdTest extends TestCase
+{
+    public function testDifferentPathsGetDifferentCacheIds()
+    {
+        $first = View::cacheIdForRequest('/blog/first-post');
+        $second = View::cacheIdForRequest('/blog/second-post');
+
+        $this->assertNotEquals($first, $second);
+    }
+
+    public function testSamePathGetsTheSameCacheId()
+    {
+        $this->assertEquals(
+            View::cacheIdForRequest('/blog/first-post'),
+            View::cacheIdForRequest('/blog/first-post')
+        );
+    }
+
+    public function testQueryStringIsPartOfTheCacheId()
+    {
+        $this->assertNotEquals(
+            View::cacheIdForRequest('/blog?page=1'),
+            View::cacheIdForRequest('/blog?page=2')
+        );
+    }
+
+    public function testFragmentIsIgnored()
+    {
+        $this->assertEquals(
+            View::cacheIdForRequest('/blog/first-post'),
+            View::cacheIdForRequest('/blog/first-post#comments')
+        );
+    }
+
+    public function testCacheIdContainsNoSmartySeparator()
+    {
+        // Smarty treats '|' as the cache group separator
+        $this->assertStringNotContainsString('|', View::cacheIdForRequest('/a|b/c'));
+    }
+
+    public function testCacheIdIsAlwaysProduced()
+    {
+        $this->assertNotEmpty(View::cacheIdForRequest('/'));
+        $this->assertNotEmpty(View::cacheIdForRequest(''));
+    }
+
+    public function testFallsBackToTheCurrentRequestUri()
+    {
+        $_SERVER['REQUEST_URI'] = '/blog/from-server';
+
+        $this->assertEquals(
+            View::cacheIdForRequest('/blog/from-server'),
+            View::cacheIdForRequest()
+        );
+    }
+}

--- a/tests/Unit/Helpers/CacheHeaderHelperTest.php
+++ b/tests/Unit/Helpers/CacheHeaderHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use App\Helpers\CacheHeaderHelper;
+
+// Composer autoloads app/ through a classmap, so a helper added after the last
+// `composer dump-autoload` is invisible to the test run. The application itself
+// resolves it through App\Core\Autoloader's PSR-4 lookup.
+require_once dirname(__DIR__, 3) . '/app/helpers/CacheHeaderHelper.php';
+
+/**
+ * CacheHeaderHelper Test
+ * The application states its own caching policy instead of inheriting PHP's
+ * session cache limiter, which stamped no-store on every public page.
+ *
+ * @package Tests\Unit\Helpers
+ */
+class CacheHeaderHelperTest extends TestCase
+{
+    public function testAdminPagesStayUncacheable()
+    {
+        $this->assertEquals(
+            'no-store, no-cache, must-revalidate',
+            CacheHeaderHelper::policyForPath('/admin/articles')
+        );
+    }
+
+    public function testAdminRootStaysUncacheable()
+    {
+        $this->assertStringContainsString('no-store', CacheHeaderHelper::policyForPath('/admin'));
+    }
+
+    public function testAuthPagesStayUncacheable()
+    {
+        $this->assertStringContainsString('no-store', CacheHeaderHelper::policyForPath('/auth/login'));
+    }
+
+    public function testPublicPagesArePrivateButReusable()
+    {
+        $this->assertEquals(
+            'private, max-age=0, must-revalidate',
+            CacheHeaderHelper::policyForPath('/blog/first-post')
+        );
+    }
+
+    public function testHomepageIsPrivateButReusable()
+    {
+        $this->assertStringContainsString('private', CacheHeaderHelper::policyForPath('/'));
+    }
+
+    public function testPublicPolicyNeverAllowsSharedCaches()
+    {
+        // Rendered pages embed the CSRF token, so no proxy or CDN may hold them
+        $this->assertStringNotContainsString('public', CacheHeaderHelper::policyForPath('/blog'));
+    }
+
+    public function testAPathMerelyContainingAdminIsPublic()
+    {
+        $this->assertStringContainsString('private', CacheHeaderHelper::policyForPath('/blog/admin-tips'));
+    }
+
+    public function testQueryStringIsIgnored()
+    {
+        $this->assertStringContainsString('no-store', CacheHeaderHelper::policyForPath('/admin?page=2'));
+    }
+
+    public function testMissingPathFallsBackToThePublicPolicy()
+    {
+        $this->assertStringContainsString('private', CacheHeaderHelper::policyForPath(''));
+    }
+}


### PR DESCRIPTION
Closes #1, closes #11

Batch 3 of the issue triage: the two caching bugs, one commit each.

## #1 — Smarty full-page cache had no cache id

`View::render()` called `display()` with no cache id, so Smarty keyed the entry by template name alone and every URL rendered through the same template shared a single cached page for an hour. Visiting `/blog/second-post` served `/blog/first-post` back. `render()` now passes a cache id derived from the request path and query string.

**A cache id alone does not make the feature safe**, which is why this commit does a second thing. The frontend templates embed per-visitor data with no `{nocache}` regions:

- `partials/comment_form.tpl` renders `{$csrf_token}` into a hidden field;
- `layout.tpl` renders the flash messages, and it wraps every frontend page.

So even correctly keyed per URL, a cached page hands the first visitor's CSRF token and flash messages to everyone who follows for the next hour — forms rejected as expired, and one visitor's messages shown to another.

Full-page caching is therefore now opt-in through `PAGE_CACHE`. That variable was already declared in `.env.example` as `false`, alongside `PAGE_CACHE_LIFETIME`, but nothing ever read either one — the cache was on whenever `DEBUG_MODE` was off. Both constants are now wired up in `config.php`, the default stays off, and `.env.example` states what has to be true before switching it on. Compile caching is untouched, so the production `compile_check = false` behaviour is unchanged.

## #11 — session cache limiter put no-store on every page

`session_start()` ran with PHP's default limiter (`nocache`). Verified against a local PHP server, before and after:

```
--- BEFORE:
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
--- AFTER:
Cache-Control: private, max-age=0, must-revalidate
```

The limiter is off and the policy is now stated explicitly, but **not** as a single global value the way the issue proposes. `no-store` is the right answer for authenticated pages: dropping it site-wide would let an admin page stay in the browser's disk and back/forward cache after logout. So `CacheHeaderHelper` picks per area — `/admin` and `/auth` keep `no-store, no-cache, must-revalidate`, everything else gets `private, max-age=0, must-revalidate`. Public pages become browser-reusable and regain the back/forward cache; shared caches are still excluded everywhere, because a rendered page embeds the CSRF token and, when logged in, the user's display name.

The issue also suggests `public, max-age=3600` for `sitemap.xml`, `feed.xml` and `robots.txt`. **Those endpoints do not exist in this codebase** — there is no route and no static file for any of the three, so there was nothing to override. Adding them would be a feature, not this fix; the policy above will apply to them once they exist.

## Testing

- `tests/Unit/Cache/ViewCacheIdTest.php` (7 tests): different paths produce different ids, the same path is stable, the query string participates, the fragment does not, and the id never contains `|`, which Smarty reads as its cache group separator.
- `tests/Unit/Helpers/CacheHeaderHelperTest.php` (9 tests): admin and auth stay `no-store`, public paths are `private` and never `public`, a path merely containing the word "admin" (`/blog/admin-tips`) is treated as public, and a query string does not confuse the prefix match.
- Header behaviour confirmed end to end with `php -S` and `curl -I`, output above.
- `Smarty::display($template, $cache_id, $compile_id)` signature checked against the vendored Smarty 5 (`vendor/smarty/smarty/src/Smarty.php:2130`).

`tests/Unit`: 203 tests, 23 errors — the same 23 present on `main` (no MySQL and an unwritable `logs/` on this host; `vendor/` belongs to `www-data` from the container). `phpcs --standard=PSR12` reports nothing on the new and changed lines; the three long-line warnings in `View.php` are outside these hunks.

## Note for the reviewer

`tests/Unit/Helpers/CacheHeaderHelperTest.php` `require_once`s the helper, as the password-reset test does: Composer autoloads `app/` through a classmap, so a newly added class is invisible to the test run until `composer dump-autoload` runs, and `vendor/` is not writable from the host here. The application resolves it through `App\Core\Autoloader`'s PSR-4 lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)