### PR TITLE
fix: media admin — getById() not-found contract, featured_image cleanup, view route

### DIFF
--- a/app/controllers/admin/MediaController.php
+++ b/app/controllers/admin/MediaController.php
@@ -66,8 +66,13 @@ class MediaController extends AdminController
      * @param int $id Media item ID
      * @return void
      */
-    public function viewAction($id)
+    public function viewAction($id = 0)
     {
+        // The router dispatches actions with no arguments and passes the route
+        // captures as $this->params, the way the sibling actions read them.
+        if (empty($id)) {
+            $id = $this->params[0] ?? 0;
+        }
         if (empty($id) || !is_numeric($id)) {
             RedirectHelper::redirect('/admin/media');
         }

--- a/app/models/MediaModel.php
+++ b/app/models/MediaModel.php
@@ -34,10 +34,21 @@ class MediaModel extends Model
         'mp3' => ['audio/mpeg'], 'wav' => ['audio/wav', 'audio/x-wav'], 'ogg' => ['audio/ogg', 'application/ogg'],
     ];
 
-    public function __construct()
+    /**
+     * Constructor
+     *
+     * @param \PDO|null $pdo Optional connection, mainly for tests
+     */
+    public function __construct(\PDO $pdo = null)
     {
         parent::__construct();
         $this->table = 'media';
+
+        if ($pdo !== null) {
+            // An injected connection replaces the Database singleton, which lets
+            // the model be exercised against an in-memory SQLite database.
+            $this->db = $pdo;
+        }
     }
 
     /**
@@ -302,13 +313,18 @@ class MediaModel extends Model
 
 
     // Ottieni un media per ID
-    public function getById($id): object
+    public function getById($id): ?object
     {
         $sql = "SELECT * FROM media WHERE id = :id LIMIT 1";
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', $id, $this->db::PARAM_INT);
         $stmt->execute();
-        return $stmt->fetch($this->db::FETCH_OBJ);
+
+        // fetch() returns false when no row matches: hand back null so callers
+        // can test the result instead of hitting a TypeError on the way out.
+        $media = $stmt->fetch($this->db::FETCH_OBJ);
+
+        return $media === false ? null : $media;
     }
 
     // Lista media con filtri e paginazione
@@ -439,10 +455,16 @@ class MediaModel extends Model
         if (file_exists($thumbPath)) {
             @unlink($thumbPath);
         }
-        // Reset featured_image nei post che usano questo media
-        $sql = "UPDATE posts SET featured_image = NULL WHERE featured_image = :media_id";
+        // Reset featured_image nei post che usano questo media.
+        // featured_image holds the public URL the media picker inserted, not an id
+        // and not a filesystem path; for images the picker stores the thumbnail URL,
+        // so both spellings have to be cleared.
+        $webPath = '/uploads/media/' . ltrim($media->filepath, '/') . $media->filename;
+        $thumbWebPath = '/uploads/media/' . ltrim($media->filepath, '/') . 'thumbs/' . $media->filename;
+        $sql = "UPDATE posts SET featured_image = NULL WHERE featured_image IN (:web_path, :thumb_web_path)";
         $stmt = $this->db->prepare($sql);
-        $stmt->bindValue(':media_id', $filePath, $this->db::PARAM_STR);
+        $stmt->bindValue(':web_path', $webPath, $this->db::PARAM_STR);
+        $stmt->bindValue(':thumb_web_path', $thumbWebPath, $this->db::PARAM_STR);
         $stmt->execute();
         // Cancella record dal database
         $this->delete($id);

--- a/tests/Unit/Models/MediaModelTest.php
+++ b/tests/Unit/Models/MediaModelTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use PHPUnit\Framework\TestCase;
+use App\Models\MediaModel;
+
+/**
+ * MediaModel Test
+ * Covers the "not found" contract of getById() and the featured_image cleanup
+ * deleteMedia() performs, both against an in-memory SQLite database.
+ *
+ * @package Tests\Unit\Models
+ */
+class MediaModelTest extends TestCase
+{
+    /** @var \PDO */
+    private $pdo;
+
+    /** @var MediaModel */
+    private $model;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pdo = new \PDO('sqlite::memory:');
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec("CREATE TABLE media (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filename VARCHAR(255) NOT NULL,
+            filepath VARCHAR(255) NOT NULL,
+            filetype VARCHAR(100) NOT NULL DEFAULT 'image/jpeg',
+            filesize INTEGER NOT NULL DEFAULT 0,
+            title VARCHAR(255) DEFAULT NULL,
+            description TEXT DEFAULT NULL,
+            alt_text VARCHAR(255) DEFAULT NULL,
+            user_id INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT NULL
+        )");
+        $this->pdo->exec("CREATE TABLE posts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title VARCHAR(255) NOT NULL,
+            featured_image VARCHAR(255) DEFAULT NULL
+        )");
+
+        $this->model = new MediaModel($this->pdo);
+    }
+
+    private function insertMedia(string $filepath = '/2026/08/', string $filename = 'photo.jpg'): int
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO media (filename, filepath, filetype) VALUES (:filename, :filepath, 'image/jpeg')"
+        );
+        $stmt->execute(['filename' => $filename, 'filepath' => $filepath]);
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    private function insertPost(string $title, $featuredImage): int
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO posts (title, featured_image) VALUES (:title, :featured_image)"
+        );
+        $stmt->execute(['title' => $title, 'featured_image' => $featuredImage]);
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    private function featuredImageOf(int $postId)
+    {
+        $stmt = $this->pdo->prepare("SELECT featured_image FROM posts WHERE id = :id");
+        $stmt->execute(['id' => $postId]);
+
+        return $stmt->fetchColumn();
+    }
+
+    public function testGetByIdReturnsNullWhenNoRowMatches()
+    {
+        $this->assertNull($this->model->getById(999999));
+    }
+
+    public function testGetByIdReturnsTheRow()
+    {
+        $id = $this->insertMedia();
+
+        $media = $this->model->getById($id);
+
+        $this->assertIsObject($media);
+        $this->assertEquals('photo.jpg', $media->filename);
+    }
+
+    public function testDeleteMediaClearsPostsReferencingTheFullSizeUrl()
+    {
+        $id = $this->insertMedia();
+        $postId = $this->insertPost('With image', '/uploads/media/2026/08/photo.jpg');
+
+        $this->model->deleteMedia($id);
+
+        $this->assertNull($this->featuredImageOf($postId));
+    }
+
+    public function testDeleteMediaClearsPostsReferencingTheThumbnailUrl()
+    {
+        // The media picker stores the thumbnail URL for images
+        $id = $this->insertMedia();
+        $postId = $this->insertPost('With thumb', '/uploads/media/2026/08/thumbs/photo.jpg');
+
+        $this->model->deleteMedia($id);
+
+        $this->assertNull($this->featuredImageOf($postId));
+    }
+
+    public function testDeleteMediaLeavesOtherPostsAlone()
+    {
+        $id = $this->insertMedia();
+        $otherPost = $this->insertPost('Other image', '/uploads/media/2026/08/other.jpg');
+
+        $this->model->deleteMedia($id);
+
+        $this->assertEquals('/uploads/media/2026/08/other.jpg', $this->featuredImageOf($otherPost));
+    }
+
+    public function testDeleteMediaRemovesTheRow()
+    {
+        $id = $this->insertMedia();
+
+        $this->model->deleteMedia($id);
+
+        $this->assertNull($this->model->getById($id));
+    }
+
+    public function testDeleteMediaThrowsWhenTheMediaIsMissing()
+    {
+        $this->expectException(\Exception::class);
+
+        $this->model->deleteMedia(999999);
+    }
+}

--- a/tests/Unit/RoutedActionsSignatureTest.php
+++ b/tests/Unit/RoutedActionsSignatureTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Core\Router;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Routed actions signature Test
+ *
+ * Router::dispatch() calls actions with no arguments ($controllerObject->$action()),
+ * handing route captures to the controller as $this->params instead. An action
+ * declaring a required parameter therefore fails with an ArgumentCountError the
+ * moment its route is requested.
+ *
+ * @package Tests\Unit
+ */
+class RoutedActionsSignatureTest extends TestCase
+{
+    /**
+     * @return array<int, array{0: string, 1: string}> [class, method] pairs
+     */
+    private function routedActions(): array
+    {
+        $router = new Router();
+        $routesProperty = (new ReflectionClass($router))->getProperty('routes');
+        $routesProperty->setAccessible(true);
+
+        $actions = [];
+        foreach ($routesProperty->getValue($router) as $params) {
+            if (empty($params['controller']) || empty($params['action'])) {
+                continue;
+            }
+
+            $method = $this->toCamelCase($params['action']) . 'Action';
+
+            foreach (['App\\Controllers\\Admin\\', 'App\\Controllers\\Frontend\\'] as $namespace) {
+                $class = $namespace . $params['controller'] . 'Controller';
+                if (class_exists($class) && method_exists($class, $method)) {
+                    $actions[$class . '::' . $method] = [$class, $method];
+                    break;
+                }
+            }
+        }
+
+        return array_values($actions);
+    }
+
+    private function toCamelCase(string $value): string
+    {
+        return lcfirst(str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $value))));
+    }
+
+    public function testEveryRoutedActionIsCallableWithoutArguments()
+    {
+        $actions = $this->routedActions();
+
+        $this->assertNotEmpty($actions, 'No routed actions were resolved — the test would prove nothing');
+
+        $offenders = [];
+        foreach ($actions as [$class, $method]) {
+            $required = (new ReflectionMethod($class, $method))->getNumberOfRequiredParameters();
+            if ($required > 0) {
+                $offenders[] = $class . '::' . $method . '() requires ' . $required . ' argument(s)';
+            }
+        }
+
+        $this->assertSame([], $offenders, "Router dispatches actions with no arguments:\n" . implode("\n", $offenders));
+    }
+}


### PR DESCRIPTION
Closes #2, closes #3

Batch 4 of the issue triage: the two media bugs, one commit each.

## #2 — `getById()` typed `: object`, returns `false`

`MediaModel::getById()` returned `PDOStatement::fetch()` straight out, which is `false` when no row matches, against a declared `: object`. Every "not found" path raised `TypeError: MediaModel::getById(): Return value must be of type object, bool returned` before the caller's `if (!$media)` could run — and since `Model::update()` and `Model::delete()` both call `getById()` on entry, updating or deleting an already-removed item hit the same wall. The type is now `?object` and a missing row comes back as `null`.

The second defect in that issue, the `featured_image` cleanup in `deleteMedia()`, needed the surrounding code read before it could be fixed properly:

```php
$sql = "UPDATE posts SET featured_image = NULL WHERE featured_image = :media_id";
$stmt->bindValue(':media_id', $filePath, $this->db::PARAM_STR);
```

`posts.featured_image` is a `VARCHAR(255)` rendered straight into `<img src>` (`article.tpl:44`, `home.tpl:54`), so it holds neither an id — despite the placeholder name — nor a filesystem path, but the public URL the media picker inserted. And the picker inserts `'/uploads/media' + filepath + 'thumbs/' + filename` for images, falling back to the full-size URL only for SVG (`_article_scripts.tpl:150-152`), so the **thumbnail** URL is what usually ends up stored. The cleanup now clears both spellings.

## #3 — `viewAction($id)` dispatched with no arguments

`Router::dispatch()` calls `$controllerObject->$action()` and hands the route captures to the controller as `$this->params`, but `MediaController::viewAction($id)` declared a required parameter, so `/admin/media/view/1` always ended in an `ArgumentCountError`. It now falls back to `$this->params[0]` exactly as `editAction()` and `updateAction()` already do.

The issue also names the `viewAction()` signatures in the frontend Article and Page controllers. I checked every registered route: `admin/media/view/([0-9]+)` is the only one pointing at a `view` action, so those two are unreachable and are left alone — the new test below covers them automatically if a route is ever added.

## Testing

- `tests/Unit/Models/MediaModelTest.php` (7 tests) against in-memory SQLite: `getById()` returns null for a missing row and the object for a present one; `deleteMedia()` clears posts referencing the full-size URL, clears posts referencing the thumbnail URL, leaves unrelated posts untouched, removes the row, and throws for a missing media. Written first — they failed with the exact `TypeError` from the issue.
- `tests/Unit/RoutedActionsSignatureTest.php` walks every route `Router` registers, resolves the controller action it names, and asserts it is callable with no arguments. It failed on `MediaController::viewAction() requires 1 argument(s)` and nothing else, which is also how I confirmed the frontend actions are unrouted.
- `MediaModel` gained an optional PDO constructor argument, the same pattern `PasswordReset` and the `Migration` classes already use, so it can be exercised without the `Database` singleton.

`phpcs --standard=PSR12` is clean on both changed files.

## Note on how to run the suite

`tests/bootstrap.php` exists and defines every path constant plus an in-memory SQLite schema, but `phpunit.xml` is listed in `.gitignore` and is absent from a fresh clone, so `phpunit` runs without it and a lot of tests fail on missing constants. Run:

```
DB_DRIVER=sqlite php vendor/bin/phpunit --bootstrap tests/bootstrap.php --do-not-cache-result tests/Unit
```

Baseline on `main` that way: 187 tests, 1 error. With this branch: 195 tests, the same 1 error — `logs/error.log` is not writable from the host, since `logs/` and `vendor/` belong to `www-data` from the container. (The higher error counts I quoted in earlier PRs came from running without the bootstrap; the fixes themselves are unaffected.) A committed `phpunit.xml.dist` would make this the default and is worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)