### PR TITLE
chore: add a committed phpunit.xml.dist so the test bootstrap is picked up

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         cacheResultFile=".phpunit.result.cache"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         beStrictAboutOutputDuringTests="false"
+         failOnWarning="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+        <testsuite name="Functional">
+            <directory>tests/Functional</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">app</directory>
+        </include>
+    </coverage>
+
+    <!--
+        The database driver is deliberately not set here. tests/bootstrap.php reads
+        it from the environment and falls back to MySQL, which is what the app
+        container provides, so running phpunit inside the container tests against
+        the real database.
+
+        On a host without MySQL, set DB_DRIVER=sqlite and the bootstrap builds an
+        in-memory database instead; the Unit suite is the one that runs that way.
+    -->
+</phpunit>


### PR DESCRIPTION
## What

`tests/bootstrap.php` already does everything the suite needs — defines the path constants, points the SQLite driver at an in-memory database, creates the minimal schema, and sets the session ini values tests depend on. But `phpunit.xml` is listed in `.gitignore`, so a fresh clone has no PHPUnit config at all and the bootstrap is never loaded. Tests then fail on undefined constants and on `session_start(): Session cannot be started after headers have already been sent`, and the commands in CLAUDE.md that name a testsuite (`--testsuite Unit`, `--testsuite Integration`) fail outright, because no suites are defined anywhere.

`phpunit.xml.dist` is not covered by the ignore rule (`/phpunit.xml` matches only the exact name), so it ships with the repo and PHPUnit falls back to it. A developer who wants local overrides still writes their own `phpunit.xml`, which keeps taking precedence.

## Measured effect on this branch, no application code touched

| command | before | after |
|---|---|---|
| `--testsuite Unit` | not runnable (no suite); by path: 187 tests, 23 errors | 187 tests, 1 error |
| `--testsuite Integration` | not runnable; by path: 47 tests, 40 errors | 47 tests, 0 errors |

The one remaining error is `logs/error.log` not being writable from the host, because `logs/` belongs to `www-data` from the container. Nothing in the config hides it.

## Two decisions worth flagging

- **The database driver is deliberately not set.** `docker-compose.yml` passes `DB_HOST`/`DB_NAME`/`DB_USER`/`DB_PASS` but not `DB_DRIVER`, and the bootstrap falls back to MySQL when it is unset. Pinning `sqlite` in the config would silently switch the documented container command (`docker exec swcms_app php vendor/bin/phpunit`) onto an in-memory database with only two tables. So the driver stays an environment decision, and the file says so in a comment: MySQL in the container, `DB_DRIVER=sqlite` on a host without one.
- **`cacheResultFile` points at the project root.** The default lives next to the PHPUnit binary, and `vendor/` is owned by `www-data`, so PHPUnit died on `file_put_contents(vendor/bin/.phpunit.result.cache): Permission denied` after printing the results. `.phpunit.result.cache` is already in `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)