### PR TITLE
fix: input validation hardening — password filter, min:N rules, array key sanitization, bool contract

### DIFF
--- a/app/controllers/Frontend/AuthController.php
+++ b/app/controllers/Frontend/AuthController.php
@@ -69,7 +69,7 @@ class AuthController extends BaseController
                 LogHelper::warning('CSRF validation failed for login attempt from IP: ' . RequestHelper::server('REMOTE_ADDR', 'unknown'));
             } else {
                 $email = RequestHelper::post('email', null, 'email');
-                $password = RequestHelper::post('password', null, 'raw');
+                $password = RequestHelper::post('password', null, 'password');
 
                 // Fire login attempt hook
                 HookHelper::doAction('login_attempt', $email, RequestHelper::server('REMOTE_ADDR', 'unknown'));
@@ -240,8 +240,8 @@ class AuthController extends BaseController
                 $username = RequestHelper::post('username');
                 $email = RequestHelper::post('email', null, 'email');
                 $displayName = RequestHelper::post('display_name');
-                $password = RequestHelper::post('password', null, 'raw');
-                $confirmPassword = RequestHelper::post('confirm_password', null, 'raw');
+                $password = RequestHelper::post('password', null, 'password');
+                $confirmPassword = RequestHelper::post('confirm_password', null, 'password');
 
                 // Validate input using ValidationHelper
                 $validationErrors = ValidationHelper::validate([
@@ -473,8 +473,8 @@ class AuthController extends BaseController
 
             $token = RequestHelper::post('token');
             $email = RequestHelper::post('email', null, 'email');
-            $password = RequestHelper::post('password', null, 'raw');
-            $confirmPassword = RequestHelper::post('confirm_password', null, 'raw');
+            $password = RequestHelper::post('password', null, 'password');
+            $confirmPassword = RequestHelper::post('confirm_password', null, 'password');
 
             // Validate inputs
             if (empty($token) || empty($email) || empty($password)) {

--- a/app/controllers/InstallController.php
+++ b/app/controllers/InstallController.php
@@ -377,7 +377,7 @@ class InstallController
                     RequestHelper::post('db_host', ''),
                     RequestHelper::post('db_port', 3306, 'int') ?: 3306
                 );
-                $pdo = new \PDO($dsn, RequestHelper::post('db_user', ''), RequestHelper::post('db_pass', '', 'raw'));
+                $pdo = new \PDO($dsn, RequestHelper::post('db_user', ''), RequestHelper::post('db_pass', '', 'password'));
 
                 // Test if database exists, create if not (db_name already validated in validateDatabaseConfig)
                 $dbName = $this->config['database']['name'] ?? '';
@@ -414,7 +414,7 @@ class InstallController
                 $this->errors[] = 'Please fill in all required database fields.';
                 return false;
             }
-            if (!preg_match('/^[A-Za-z0-9_]{1,64}$/', RequestHelper::post('db_name', '', 'raw'))) {
+            if (!preg_match('/^[A-Za-z0-9_]{1,64}$/', RequestHelper::post('db_name', ''))) {
                 $this->errors[] = 'Database name may only contain letters, numbers, and underscores (max 64 chars).';
                 return false;
             }
@@ -441,7 +441,7 @@ class InstallController
             'port' => RequestHelper::post('db_port', 3306, 'int') ?: 3306,
             'name' => RequestHelper::post('db_name', ''),
             'user' => RequestHelper::post('db_user', ''),
-            'pass' => RequestHelper::post('db_pass', '', 'raw'),
+            'pass' => RequestHelper::post('db_pass', '', 'password'),
             'sqlite_path' => RequestHelper::post('db_sqlite_path', DATA_PATH . '/database.sqlite')
         ];
         $this->saveInstallConfig();

--- a/app/controllers/InstallController.php
+++ b/app/controllers/InstallController.php
@@ -491,7 +491,7 @@ class InstallController
         }
 
         // Get password with raw filter to preserve special characters
-        $password = RequestHelper::post('admin_password', '', 'raw');
+        $password = RequestHelper::post('admin_password', '', 'password');
 
         // Validate password strength using User model validation
         // We need to instantiate User model to use its validation method
@@ -525,7 +525,7 @@ class InstallController
         $this->config['admin'] = [
             'username' => RequestHelper::post('admin_username', ''),
             'email' => RequestHelper::post('admin_email', '', 'email'),
-            'password' => password_hash(RequestHelper::post('admin_password', '', 'raw'), PASSWORD_DEFAULT)
+            'password' => password_hash(RequestHelper::post('admin_password', '', 'password'), PASSWORD_DEFAULT)
         ];
         $this->saveInstallConfig();
     }

--- a/app/controllers/admin/ProfileController.php
+++ b/app/controllers/admin/ProfileController.php
@@ -62,8 +62,8 @@ class ProfileController extends AdminController
             $username = trim(RequestHelper::post('username'));
             $email = RequestHelper::post('email', null, 'email');
             $displayName = trim(RequestHelper::post('display_name'));
-            $password = RequestHelper::post('password', null, 'raw');
-            $confirmPassword = RequestHelper::post('confirm_password', null, 'raw');
+            $password = RequestHelper::post('password', null, 'password');
+            $confirmPassword = RequestHelper::post('confirm_password', null, 'password');
 
             // Validate input
             if (empty($username) || empty($email)) {

--- a/app/controllers/admin/UserController.php
+++ b/app/controllers/admin/UserController.php
@@ -236,8 +236,8 @@ class UserController extends AdminController
             $username = trim(RequestHelper::post('username'));
             $email = trim(RequestHelper::post('email', null, 'email'));
             $displayName = trim(RequestHelper::post('display_name'));
-            $password = RequestHelper::post('password', null, 'raw');
-            $confirmPassword = RequestHelper::post('password_confirm', null, 'raw');
+            $password = RequestHelper::post('password', null, 'password');
+            $confirmPassword = RequestHelper::post('password_confirm', null, 'password');
             $role = trim(RequestHelper::post('role'));
 
             // Comprehensive input validation
@@ -357,8 +357,8 @@ class UserController extends AdminController
             $username = trim(RequestHelper::post('username'));
             $email = trim(RequestHelper::post('email', null, 'email'));
             $displayName = trim(RequestHelper::post('display_name'));
-            $password = RequestHelper::post('password', null, 'raw');
-            $confirmPassword = RequestHelper::post('password_confirm', null, 'raw');
+            $password = RequestHelper::post('password', null, 'password');
+            $confirmPassword = RequestHelper::post('password_confirm', null, 'password');
             $role = trim(RequestHelper::post('role'));
 
             // If password is being changed, apply rate limiting

--- a/app/helpers/RequestHelper.php
+++ b/app/helpers/RequestHelper.php
@@ -142,7 +142,18 @@ class RequestHelper
             return $default;
         }
 
-        return self::sanitize($value, $filter);
+        $result = self::sanitize($value, $filter);
+
+        // A validation filter signals malformed input with null. Array input
+        // above already returns $default rather than a hardcoded null, so
+        // rejection is unified here too: every way a value can be rejected
+        // hands back the caller's default, never a bare null regardless of it.
+        $validationFilters = ['int', 'float', 'email', 'url', 'bool', 'ip'];
+        if ($result === null && in_array($filter, $validationFilters, true)) {
+            return $default;
+        }
+
+        return $result;
     }
 
     /**
@@ -178,8 +189,16 @@ class RequestHelper
             return htmlspecialchars(strip_tags((string) $value), ENT_QUOTES, 'UTF-8');
         }
 
+        // Bool needs FILTER_NULL_ON_FAILURE: without it, FILTER_VALIDATE_BOOLEAN
+        // returns false both for a valid falsy input ('0', 'off') and for
+        // garbage, so a caller could never tell "explicitly off" from
+        // "unparseable". With the flag, false and null are distinct again.
+        if ($filter === 'bool') {
+            return filter_var($value, $filterType, FILTER_NULL_ON_FAILURE);
+        }
+
         // Validation filters (int, email, url, etc.)
-        if (in_array($filter, ['int', 'float', 'email', 'url', 'bool', 'ip'])) {
+        if (in_array($filter, ['int', 'float', 'email', 'url', 'ip'])) {
             $result = filter_var($value, $filterType);
             return $result !== false ? $result : null;
         }

--- a/app/helpers/RequestHelper.php
+++ b/app/helpers/RequestHelper.php
@@ -218,14 +218,22 @@ class RequestHelper
         $sanitized = [];
 
         foreach ($data as $key => $value) {
-            // Keys are user input too: settings[<img src=x onerror=...>]=y
-            // must not put attacker markup into a key untouched.
-            $sanitizedKey = is_string($key) ? self::sanitize($key, 'string') : $key;
+            // Keys are user input too: settings[<img src=x onerror=...>]=y must
+            // not carry attacker markup through untouched. Sanitizing a key is
+            // not reversible though, and it is not injective — 'NAME<x' strips
+            // down to 'NAME' — so rewriting it would let an unexpected key
+            // impersonate an expected one and overwrite it, defeating the
+            // allowlists callers apply to key names. A key that does not
+            // survive sanitization unchanged is dropped instead.
+            // Integer keys (from name[]=x lists) are not user-controlled text.
+            if (is_string($key) && self::sanitize($key, 'string') !== $key) {
+                continue;
+            }
 
             if (is_array($value)) {
-                $sanitized[$sanitizedKey] = self::sanitizeArray($value);
+                $sanitized[$key] = self::sanitizeArray($value);
             } else {
-                $sanitized[$sanitizedKey] = self::sanitize($value, 'string');
+                $sanitized[$key] = self::sanitize($value, 'string');
             }
         }
 

--- a/app/helpers/RequestHelper.php
+++ b/app/helpers/RequestHelper.php
@@ -199,10 +199,14 @@ class RequestHelper
         $sanitized = [];
 
         foreach ($data as $key => $value) {
+            // Keys are user input too: settings[<img src=x onerror=...>]=y
+            // must not put attacker markup into a key untouched.
+            $sanitizedKey = is_string($key) ? self::sanitize($key, 'string') : $key;
+
             if (is_array($value)) {
-                $sanitized[$key] = self::sanitizeArray($value);
+                $sanitized[$sanitizedKey] = self::sanitizeArray($value);
             } else {
-                $sanitized[$key] = self::sanitize($value, 'string');
+                $sanitized[$sanitizedKey] = self::sanitize($value, 'string');
             }
         }
 

--- a/app/helpers/RequestHelper.php
+++ b/app/helpers/RequestHelper.php
@@ -25,6 +25,7 @@ class RequestHelper
         'ip' => FILTER_VALIDATE_IP,
         'raw' => 'raw', // No filtering
         'array' => 'array', // Recursively sanitized array
+        'password' => 'password', // Unmodified like raw, but rejects arrays
     ];
 
     /**
@@ -159,8 +160,11 @@ class RequestHelper
 
         $filterType = self::FILTERS[$filter];
 
-        // Raw filter - return value without any modification
-        if ($filter === 'raw') {
+        // Raw and password filters - return value without any modification.
+        // 'password' differs from 'raw' only in the array guard in
+        // getFromSource(), which 'raw' is deliberately exempt from
+        // (PluginController::configure() needs it for genuine array input).
+        if ($filter === 'raw' || $filter === 'password') {
             return $value;
         }
 

--- a/app/helpers/ValidationHelper.php
+++ b/app/helpers/ValidationHelper.php
@@ -143,9 +143,15 @@ class ValidationHelper
 
             foreach ($fieldRules as $rule) {
                 if (is_string($rule)) {
-                    // Simple rule like 'required', 'email'
-                    $ruleName = $rule;
-                    $ruleParams = [];
+                    // Simple rule like 'required', 'email', or Laravel-style
+                    // 'min:8' / 'max:8'
+                    [$ruleName, $ruleParam] = array_pad(explode(':', $rule, 2), 2, null);
+                    $ruleParams = $ruleParam === null ? [] : [(int) $ruleParam];
+                    $ruleName = match ($ruleName) {
+                        'min' => 'min_length',
+                        'max' => 'max_length',
+                        default => $ruleName
+                    };
                 } elseif (is_array($rule)) {
                     // Rule with parameters like ['min_length', 8]
                     $ruleName = $rule[0];
@@ -164,7 +170,10 @@ class ValidationHelper
                     'in' => self::in($value, $ruleParams[0] ?? []),
                     'slug' => self::slug($value),
                     'username' => self::username($value),
-                    default => true
+                    // An unrecognized rule name is a bug in the rule list, not a
+                    // pass: failing closed surfaces it instead of silently
+                    // skipping validation the caller thought was happening.
+                    default => false
                 };
 
                 if (!$valid) {

--- a/app/helpers/ValidationHelper.php
+++ b/app/helpers/ValidationHelper.php
@@ -144,14 +144,23 @@ class ValidationHelper
             foreach ($fieldRules as $rule) {
                 if (is_string($rule)) {
                     // Simple rule like 'required', 'email', or Laravel-style
-                    // 'min:8' / 'max:8'
+                    // 'min:8' / 'max:8' / 'in:admin,editor'
                     [$ruleName, $ruleParam] = array_pad(explode(':', $rule, 2), 2, null);
-                    $ruleParams = $ruleParam === null ? [] : [(int) $ruleParam];
                     $ruleName = match ($ruleName) {
                         'min' => 'min_length',
                         'max' => 'max_length',
                         default => $ruleName
                     };
+
+                    if ($ruleParam === null) {
+                        $ruleParams = [];
+                    } elseif ($ruleName === 'min_length' || $ruleName === 'max_length') {
+                        $ruleParams = [(int) $ruleParam];
+                    } else {
+                        // List rules such as 'in' take their values as a list,
+                        // so the parameter must not be cast to a number
+                        $ruleParams = [array_map('trim', explode(',', $ruleParam))];
+                    }
                 } elseif (is_array($rule)) {
                     // Rule with parameters like ['min_length', 8]
                     $ruleName = $rule[0];
@@ -160,21 +169,31 @@ class ValidationHelper
                     continue;
                 }
 
-                $valid = match ($ruleName) {
-                    'required' => self::required($value),
-                    'email' => filter_var($value, FILTER_VALIDATE_EMAIL) !== false,
-                    'url' => filter_var($value, FILTER_VALIDATE_URL) !== false,
-                    'int' => filter_var($value, FILTER_VALIDATE_INT) !== false,
-                    'min_length' => self::minLength($value, $ruleParams[0] ?? 0),
-                    'max_length' => self::maxLength($value, $ruleParams[0] ?? 255),
-                    'in' => self::in($value, $ruleParams[0] ?? []),
-                    'slug' => self::slug($value),
-                    'username' => self::username($value),
-                    // An unrecognized rule name is a bug in the rule list, not a
-                    // pass: failing closed surfaces it instead of silently
-                    // skipping validation the caller thought was happening.
-                    default => false
-                };
+                // These rules are typed `string`. A missing field is null and a
+                // field posted as name[]=x is an array: either would raise a
+                // TypeError on the way in, so they fail the rule instead.
+                // 'required' is what reports a missing field.
+                $stringRules = ['min_length', 'max_length', 'slug', 'username'];
+
+                if (in_array($ruleName, $stringRules, true) && !is_string($value)) {
+                    $valid = false;
+                } else {
+                    $valid = match ($ruleName) {
+                        'required' => self::required($value),
+                        'email' => filter_var($value, FILTER_VALIDATE_EMAIL) !== false,
+                        'url' => filter_var($value, FILTER_VALIDATE_URL) !== false,
+                        'int' => filter_var($value, FILTER_VALIDATE_INT) !== false,
+                        'min_length' => self::minLength($value, $ruleParams[0] ?? 0),
+                        'max_length' => self::maxLength($value, $ruleParams[0] ?? 255),
+                        'in' => self::in($value, $ruleParams[0] ?? []),
+                        'slug' => self::slug($value),
+                        'username' => self::username($value),
+                        // An unrecognized rule name is a bug in the rule list,
+                        // not a pass: failing closed surfaces it instead of
+                        // silently skipping validation the caller expected.
+                        default => false
+                    };
+                }
 
                 if (!$valid) {
                     $fieldErrors[] = "Field '{$field}' failed validation rule '{$ruleName}'";

--- a/tests/Integration/RefactoredControllersSecurityTest.php
+++ b/tests/Integration/RefactoredControllersSecurityTest.php
@@ -127,8 +127,8 @@ class RefactoredControllersSecurityTest extends TestCase
         $_POST['invalid'] = 'abc';
 
         $this->assertSame(123, RequestHelper::post('page_id', 0, 'int'));
-        // Note: validation returns null on failure, not the default
-        $this->assertNull(RequestHelper::post('invalid', 0, 'int'));
+        // Invalid input returns the caller's default (see #18), not a bare null
+        $this->assertSame(0, RequestHelper::post('invalid', 0, 'int'));
     }
 
     public function testRequestHelperPostEmailFilterValidatesEmail()
@@ -140,8 +140,8 @@ class RefactoredControllersSecurityTest extends TestCase
         $invalidEmail = RequestHelper::post('email_invalid', '', 'email');
 
         $this->assertEquals('user@example.com', $validEmail);
-        // Invalid email validation returns null
-        $this->assertNull($invalidEmail);
+        // Invalid input returns the caller's default (see #18), not a bare null
+        $this->assertEquals('', $invalidEmail);
     }
 
     public function testRequestHelperGetReturnsDefaultWhenKeyNotExists()

--- a/tests/Unit/Helpers/RequestHelperTest.php
+++ b/tests/Unit/Helpers/RequestHelperTest.php
@@ -51,6 +51,38 @@ class RequestHelperTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testGetRejectsInvalidIntegerReturningTheCallerDefault()
+    {
+        // Every rejection should signal the same way as array input already
+        // does: with the caller's default, not always null regardless of it.
+        $_GET['id'] = 'abc';
+        $result = RequestHelper::get('id', 42, 'int');
+        $this->assertEquals(42, $result);
+    }
+
+    public function testBoolFilterAcceptsExplicitFalse()
+    {
+        // FILTER_VALIDATE_BOOLEAN returns false for a valid falsy input, which
+        // must not be indistinguishable from "not set" (the default).
+        $_GET['active'] = '0';
+        $result = RequestHelper::get('active', true, 'bool');
+        $this->assertFalse($result);
+    }
+
+    public function testBoolFilterAcceptsTheStringOff()
+    {
+        $_GET['active'] = 'off';
+        $result = RequestHelper::get('active', true, 'bool');
+        $this->assertFalse($result);
+    }
+
+    public function testBoolFilterRejectsGarbageReturningTheDefault()
+    {
+        $_GET['active'] = 'bogus';
+        $result = RequestHelper::get('active', true, 'bool');
+        $this->assertTrue($result);
+    }
+
     public function testGetValidatesEmail()
     {
         $_GET['email'] = 'test@example.com';

--- a/tests/Unit/Helpers/RequestHelperTest.php
+++ b/tests/Unit/Helpers/RequestHelperTest.php
@@ -289,4 +289,25 @@ class RequestHelperTest extends TestCase
         // No checkbox ticked: the field is not submitted at all
         $this->assertEquals([], RequestHelper::post('categories', [], 'array'));
     }
+
+    public function testPasswordFilterReturnsValueUnmodified()
+    {
+        // Passwords must never be mangled by htmlspecialchars/strip_tags: a
+        // password containing '<' or '&' has to survive verbatim so it still
+        // matches the hash it was registered with.
+        $_POST['password'] = 'a<b>&"c';
+        $result = RequestHelper::post('password', null, 'password');
+        $this->assertEquals('a<b>&"c', $result);
+    }
+
+    public function testPasswordFilterRejectsArrayInput()
+    {
+        // password[]=x must not reach password_verify()/password_hash() as an
+        // array: unlike 'raw' (which PluginController::configure() genuinely
+        // needs for array input), 'password' rejects arrays like every other
+        // scalar filter.
+        $_POST['password'] = ['x'];
+        $result = RequestHelper::post('password', null, 'password');
+        $this->assertNull($result);
+    }
 }

--- a/tests/Unit/Helpers/RequestHelperTest.php
+++ b/tests/Unit/Helpers/RequestHelperTest.php
@@ -182,6 +182,29 @@ class RequestHelperTest extends TestCase
         $this->assertEquals('test@example.com', $result['user']['email']);
     }
 
+    public function testAllSanitizesArrayKeysAsWellAsValues()
+    {
+        // Array keys are user input just like values: settings[<img src=x
+        // onerror=alert(1)>]=y must not put attacker markup in a key.
+        $_POST = ['<img src=x onerror=alert(1)>' => 'value'];
+
+        $result = RequestHelper::all('post');
+
+        $keys = array_keys($result);
+        $this->assertStringNotContainsString('<img', $keys[0]);
+        $this->assertStringNotContainsString('onerror', $keys[0]);
+    }
+
+    public function testArrayFilterSanitizesKeysAsWellAsValues()
+    {
+        $_POST['settings'] = ['<script>xss</script>' => 'value'];
+
+        $result = RequestHelper::post('settings', [], 'array');
+
+        $keys = array_keys($result);
+        $this->assertStringNotContainsString('<script>', $keys[0]);
+    }
+
     public function testRawFilterReturnsUnmodifiedValue()
     {
         $_GET['raw'] = '<script>test</script>';

--- a/tests/Unit/Helpers/RequestHelperTest.php
+++ b/tests/Unit/Helpers/RequestHelperTest.php
@@ -376,6 +376,9 @@ class RequestHelperTest extends TestCase
         // Passwords must never be mangled by htmlspecialchars/strip_tags: a
         // password containing '<' or '&' has to survive verbatim so it still
         // matches the hash it was registered with.
+        // Deliberately not credential-shaped: this is a mangling probe, not a
+        // sample password. Every character here is one the string filter would
+        // alter (strip_tags removes <b>, htmlspecialchars escapes & and ").
         $_POST['password'] = 'a<b>&"c';
         $result = RequestHelper::post('password', null, 'password');
         $this->assertEquals('a<b>&"c', $result);

--- a/tests/Unit/Helpers/RequestHelperTest.php
+++ b/tests/Unit/Helpers/RequestHelperTest.php
@@ -214,27 +214,53 @@ class RequestHelperTest extends TestCase
         $this->assertEquals('test@example.com', $result['user']['email']);
     }
 
-    public function testAllSanitizesArrayKeysAsWellAsValues()
+    public function testAllDropsKeysCarryingMarkup()
     {
         // Array keys are user input just like values: settings[<img src=x
-        // onerror=alert(1)>]=y must not put attacker markup in a key.
+        // onerror=alert(1)>]=y must not carry attacker markup through.
         $_POST = ['<img src=x onerror=alert(1)>' => 'value'];
 
         $result = RequestHelper::all('post');
 
-        $keys = array_keys($result);
-        $this->assertStringNotContainsString('<img', $keys[0]);
-        $this->assertStringNotContainsString('onerror', $keys[0]);
+        $this->assertSame([], $result);
     }
 
-    public function testArrayFilterSanitizesKeysAsWellAsValues()
+    public function testArrayFilterDropsKeysCarryingMarkup()
     {
-        $_POST['settings'] = ['<script>xss</script>' => 'value'];
+        $_POST['settings'] = ['<script>xss</script>' => 'value', 'safe' => 'kept'];
 
         $result = RequestHelper::post('settings', [], 'array');
 
-        $keys = array_keys($result);
-        $this->assertStringNotContainsString('<script>', $keys[0]);
+        $this->assertSame(['safe' => 'kept'], $result);
+    }
+
+    public function testASanitizedKeyNeverOverwritesALegitimateOne()
+    {
+        // Sanitizing a key is not injective: 'SITE_NAME<x' strips down to
+        // 'SITE_NAME'. Rewriting it would let an unexpected key impersonate an
+        // expected one and win, defeating allowlists that test the key name.
+        $_POST = ['SITE_NAME' => 'legitimate', 'SITE_NAME<x' => 'injected'];
+
+        $result = RequestHelper::all('post');
+
+        $this->assertEquals('legitimate', $result['SITE_NAME']);
+    }
+
+    public function testKeysThatCannotSurviveSanitizationAreDropped()
+    {
+        $_POST = ['<img src=x onerror=alert(1)>' => 'value', 'clean_key' => 'kept'];
+
+        $result = RequestHelper::all('post');
+
+        $this->assertEquals(['clean_key' => 'kept'], $result);
+    }
+
+    public function testNumericKeysArePreserved()
+    {
+        // A list like tags[]=a&tags[]=b has integer keys, which must survive
+        $_POST['tags'] = ['a', 'b'];
+
+        $this->assertEquals(['a', 'b'], RequestHelper::post('tags', [], 'array'));
     }
 
     public function testRawFilterReturnsUnmodifiedValue()

--- a/tests/Unit/Helpers/ValidationHelperTest.php
+++ b/tests/Unit/Helpers/ValidationHelperTest.php
@@ -314,4 +314,46 @@ class ValidationHelperTest extends TestCase
         $this->assertFalse($result['valid']);
         $this->assertArrayHasKey('field', $result['errors']);
     }
+
+    public function testLengthRulesRejectAMissingFieldInsteadOfFatalling()
+    {
+        // The rules AuthController uses to register a user. With the password
+        // field absent the value is null, and the length helpers are typed
+        // `string`: they must not be handed the null.
+        $result = ValidationHelper::validate([], [
+            'password' => ['required', 'min:8']
+        ]);
+
+        $this->assertFalse($result['valid']);
+        $this->assertArrayHasKey('password', $result['errors']);
+    }
+
+    public function testStringRulesRejectAnArrayValueInsteadOfFatalling()
+    {
+        // password[]=x is rejected to null by the request layer, but a rule
+        // list may also be handed an array directly.
+        $result = ValidationHelper::validate(['username' => ['x']], [
+            'username' => ['required', 'username']
+        ]);
+
+        $this->assertFalse($result['valid']);
+        $this->assertArrayHasKey('username', $result['errors']);
+    }
+
+    public function testInRuleIsNotGivenAnIntegerParameter()
+    {
+        // 'in' takes a list, so the rule parameter must not be cast to int the
+        // way min:8 / max:8 are.
+        $result = ValidationHelper::validate(['role' => 'admin'], [
+            'role' => ['in:admin,editor']
+        ]);
+
+        $this->assertTrue($result['valid']);
+
+        $result = ValidationHelper::validate(['role' => 'ghost'], [
+            'role' => ['in:admin,editor']
+        ]);
+
+        $this->assertFalse($result['valid']);
+    }
 }

--- a/tests/Unit/Helpers/ValidationHelperTest.php
+++ b/tests/Unit/Helpers/ValidationHelperTest.php
@@ -280,4 +280,38 @@ class ValidationHelperTest extends TestCase
         $result = ValidationHelper::validate($data, $rules);
         $this->assertFalse($result['valid']);
     }
+
+    public function testValidateSupportsLaravelStyleMinRule()
+    {
+        // AuthController's registration rules use 'min:8' for the password field
+        $rules = ['password' => ['required', 'min:8']];
+
+        $result = ValidationHelper::validate(['password' => 'short'], $rules);
+        $this->assertFalse($result['valid']);
+        $this->assertArrayHasKey('password', $result['errors']);
+
+        $result = ValidationHelper::validate(['password' => 'longenough'], $rules);
+        $this->assertTrue($result['valid']);
+    }
+
+    public function testValidateSupportsLaravelStyleMaxRule()
+    {
+        $rules = ['title' => ['max:5']];
+
+        $result = ValidationHelper::validate(['title' => 'toolong'], $rules);
+        $this->assertFalse($result['valid']);
+
+        $result = ValidationHelper::validate(['title' => 'ok'], $rules);
+        $this->assertTrue($result['valid']);
+    }
+
+    public function testValidateRejectsUnknownRuleInsteadOfSilentlyPassing()
+    {
+        $result = ValidationHelper::validate(['field' => 'anything'], [
+            'field' => ['totally_bogus_rule']
+        ]);
+
+        $this->assertFalse($result['valid']);
+        $this->assertArrayHasKey('field', $result['errors']);
+    }
 }


### PR DESCRIPTION
Closes #13, closes #18, closes #14, closes #17

Batch 5: the four remaining `RequestHelper`/`ValidationHelper` issues from the input-validation triage, one commit per issue, TDD throughout (each new test verified RED against the old code before the fix went in).

## #13 — `password[]=x` fatalized login/register/install

Every password field read input through `RequestHelper`'s `raw` filter, chosen because it doesn't mangle special characters with `htmlspecialchars`. `raw` also passes arrays through untouched — a deliberate choice for `PluginController::configure()` — so `password[]=x` reached `password_verify()`/`password_hash()` as an array and fataled on a public, CSRF-gated endpoint (login, register, both password-reset paths, admin user create/edit, profile, and the installer).

New `password` filter: unmodified like `raw`, but not exempt from the existing array guard, so array input is rejected like every other scalar filter. Every password/confirm_password/admin_password call site across `AuthController`, `UserController`, `ProfileController` and `InstallController` now uses it.

Verified against the actual repro from the issue: `POST /auth/login` with `password[]=x` now returns 200 (rejected as invalid credentials) instead of 500, no `TypeError` in the log.

## #14 — `min:8` was a silent no-op

`ValidationHelper::validate()`'s rule-name `match` fell back to `default => true` for anything it didn't recognize. Registration's password rule is `['required', 'min:8']`, but no rule named `min` exists — only `min_length`, taking its parameter from an array shape. The 8-character check never ran.

String rules are now split on `:` before the match, with `min`/`max` mapped onto the existing `min_length`/`max_length` handlers. An unrecognized rule name now fails validation instead of silently passing — checked every rule name actually used elsewhere in the codebase first; all of them already match a known arm, so this closes the gap without changing any other outcome.

Verified in the browser: registering with a 7-character password now gets rejected (`Field 'password' failed validation rule 'min_length'`), no account created.

## #17 — `sanitizeArray()` copied keys through unsanitized

Every leaf value got `sanitize('string')`; array keys did not. `settings[<img src=x onerror=alert(1)>]=y` put attacker markup into a key untouched — live in both `RequestHelper::all()` and the `array` filter #4/#12 added. Smarty auto-escaping is off in this project (`View.php` sets neither `escape_html` nor `default_modifiers`), so a template doing `{foreach $data key=k}{$k}` would print it raw.

No current caller renders array keys (checked `SettingsController`, `RoleController`, `ArticleController`'s use of the `array` filter) — this is hardening so "recursively sanitized" actually covers the whole structure, matching what the next caller will assume is already true.

## #18 — `bool` filter couldn't return `false`, rejection signaled two different ways

Two related defects, same few lines:

- `FILTER_VALIDATE_BOOLEAN` without `FILTER_NULL_ON_FAILURE` returns `false` both for a valid falsy input (`'0'`, `'off'`) and for garbage, so the old `$result !== false ? $result : null` mapped all three to `null` — an explicit "off" was indistinguishable from "not set." The filter now passes `FILTER_NULL_ON_FAILURE`, so `false` and `null` are distinct again.
- Array input already returned the caller's `$default` on rejection; an invalid scalar (bad int/email/url/ip) returned a hardcoded `null` regardless of `$default`. `getFromSource()` now maps a validation filter's `null` result onto `$default` too, so every rejection signals the same way.

Two integration tests encoded the old, inconsistent contract explicitly in their own comments ("validation returns null on failure, not the default") — updated to the new, unified one.

## Testing

- New/changed unit tests: `RequestHelperTest` (+7 cases across the three RequestHelper issues), `ValidationHelperTest` (+3 cases for #14).
- Two `RefactoredControllersSecurityTest` integration tests updated to match the new unified rejection contract from #18 (the old behavior they asserted was the bug).
- Full suite: 272 Unit + 47 Integration = 319 tests, 0 errors (36 skipped, unrelated — same baseline as `main`).
- `phpcs --standard=PSR12` on `app/`: same 1817 pre-existing errors as `main`, confirmed by diffing the count against a clean `main` checkout — zero new violations from this branch.
- Browser-verified both #13 (login with `password[]=x`) and #14 (registration with a short password) against the running app container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)