### PR TITLE
fix: make migrate.php up complete on MySQL

### DIFF
--- a/database/migrations/2025_05_23_000000_create_media_tables.php
+++ b/database/migrations/2025_05_23_000000_create_media_tables.php
@@ -57,7 +57,7 @@ class CreateMediaTables extends Migration
                 $this->db->exec("CREATE INDEX IF NOT EXISTS idx_media_relationships_related ON media_relationships(related_id, related_type);");
             } else {
                 // MySQL compatible CREATE TABLE for media
-                $this->exec("CREATE TABLE IF NOT EXISTS `media` (
+                $this->db->exec("CREATE TABLE IF NOT EXISTS `media` (
                     `id` int(11) NOT NULL AUTO_INCREMENT,
                     `user_id` int(11) NOT NULL,
                     `title` varchar(255) NOT NULL,
@@ -77,7 +77,7 @@ class CreateMediaTables extends Migration
                     KEY `filetype` (`filetype`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
                 // MySQL compatible CREATE TABLE for media_relationships
-                $this->exec("CREATE TABLE IF NOT EXISTS `media_relationships` (
+                $this->db->exec("CREATE TABLE IF NOT EXISTS `media_relationships` (
                     `id` int(11) NOT NULL AUTO_INCREMENT,
                     `media_id` int(11) NOT NULL,
                     `related_id` int(11) NOT NULL,

--- a/database/migrations/2025_09_03_000001_seed_roles.php
+++ b/database/migrations/2025_09_03_000001_seed_roles.php
@@ -5,6 +5,11 @@ use App\Core\Database\Migration;
 
 class SeedRoles extends Migration
 {
+    /**
+     * @var \PDO
+     */
+    protected $db;
+
     public function __construct(\PDO $pdo = null)
     {
         parent::__construct($pdo);
@@ -12,11 +17,6 @@ class SeedRoles extends Migration
 
     public function up()
     {
-        // Remove any duplicates from earlier double-seeding, then enforce
-        // uniqueness so INSERT OR IGNORE actually protects against re-runs
-        $this->db->exec("DELETE FROM roles WHERE id NOT IN (SELECT MIN(id) FROM roles GROUP BY name)");
-        $this->db->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_name ON roles(name)");
-
         $roles = [
             ['admin',      'Administrator with full access',           4],
             ['editor',     'Editor with content management access',    3],
@@ -24,12 +24,76 @@ class SeedRoles extends Migration
             ['subscriber', 'Subscriber with read-only access',         1],
         ];
 
-        $stmt = $this->db->prepare(
-            "INSERT OR IGNORE INTO roles (name, description, level) VALUES (?, ?, ?)"
+        $this->removeDuplicateRoles();
+        $this->ensureUniqueNameIndex();
+
+        // Check-then-insert rather than a dialect-specific upsert: SQLite spells
+        // it INSERT OR IGNORE and MySQL INSERT IGNORE, and IGNORE only suppresses
+        // a constraint violation, so it would silently duplicate rows anywhere
+        // the unique index below could not be created.
+        $exists = $this->db->prepare("SELECT COUNT(*) FROM roles WHERE name = ?");
+        $insert = $this->db->prepare(
+            "INSERT INTO roles (name, description, level) VALUES (?, ?, ?)"
         );
 
         foreach ($roles as [$name, $desc, $level]) {
-            $stmt->execute([$name, $desc, $level]);
+            $exists->execute([$name]);
+
+            if ((int) $exists->fetchColumn() === 0) {
+                $insert->execute([$name, $desc, $level]);
+            }
+        }
+    }
+
+    /**
+     * Drop rows left behind by an earlier double-seeding, keeping the lowest id
+     * per name.
+     *
+     * Read first and delete by explicit id: MySQL refuses a subquery that reads
+     * the table being deleted from (error 1093, and 1137 on a temporary table),
+     * so the single-statement form worked on SQLite only.
+     */
+    private function removeDuplicateRoles(): void
+    {
+        $keep = $this->db
+            ->query("SELECT MIN(id) FROM roles GROUP BY name")
+            ->fetchAll(\PDO::FETCH_COLUMN);
+
+        if (empty($keep)) {
+            return;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($keep), '?'));
+        $this->db
+            ->prepare("DELETE FROM roles WHERE id NOT IN ({$placeholders})")
+            ->execute($keep);
+    }
+
+    /**
+     * Enforce one row per role name.
+     *
+     * SQLite accepts CREATE UNIQUE INDEX IF NOT EXISTS; MySQL has no such form,
+     * so there the duplicate-index error is what tells us it is already in
+     * place. The driver is read from the connection rather than the DB_DRIVER
+     * constant, which is not necessarily the connection this migration was
+     * handed.
+     */
+    private function ensureUniqueNameIndex(): void
+    {
+        $driver = $this->db->getAttribute(\PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $this->db->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_name ON roles(name)");
+            return;
+        }
+
+        try {
+            $this->db->exec("CREATE UNIQUE INDEX idx_roles_name ON roles(name)");
+        } catch (\PDOException $e) {
+            // 1061: duplicate key name — the index is already there
+            if (($e->errorInfo[1] ?? null) !== 1061) {
+                throw $e;
+            }
         }
     }
 

--- a/database/migrations/2025_09_03_000001_seed_roles.php
+++ b/database/migrations/2025_09_03_000001_seed_roles.php
@@ -36,6 +36,10 @@ class SeedRoles extends Migration
             "INSERT INTO roles (name, description, level) VALUES (?, ?, ?)"
         );
 
+        if ($exists === false || $insert === false) {
+            $this->failed('prepare the role statements');
+        }
+
         foreach ($roles as [$name, $desc, $level]) {
             $exists->execute([$name]);
 
@@ -55,18 +59,47 @@ class SeedRoles extends Migration
      */
     private function removeDuplicateRoles(): void
     {
-        $keep = $this->db
-            ->query("SELECT MIN(id) FROM roles GROUP BY name")
-            ->fetchAll(\PDO::FETCH_COLUMN);
+        $statement = $this->db->query("SELECT MIN(id) FROM roles GROUP BY name");
+
+        if ($statement === false) {
+            $this->failed('read the existing roles');
+        }
+
+        $keep = $statement->fetchAll(\PDO::FETCH_COLUMN);
 
         if (empty($keep)) {
             return;
         }
 
         $placeholders = implode(',', array_fill(0, count($keep), '?'));
-        $this->db
-            ->prepare("DELETE FROM roles WHERE id NOT IN ({$placeholders})")
-            ->execute($keep);
+        $delete = $this->db->prepare("DELETE FROM roles WHERE id NOT IN ({$placeholders})");
+
+        if ($delete === false) {
+            $this->failed('remove duplicate roles');
+        }
+
+        $delete->execute($keep);
+    }
+
+    /**
+     * Report a statement that returned false instead of throwing.
+     *
+     * PDO only raises PDOException in exception mode. PHP 7.4 — still allowed
+     * by composer.json — defaults to ERRMODE_SILENT, and InstallController
+     * builds its connection without options, so there a failing statement
+     * returns false and the next call on it would raise an Error.
+     * MigrationRunner catches \Exception, not \Error, so that would escape as a
+     * fatal instead of being reported as a failed migration.
+     *
+     * @throws \RuntimeException
+     */
+    private function failed(string $what): void
+    {
+        $info = $this->db->errorInfo();
+
+        throw new \RuntimeException(
+            "SeedRoles could not {$what}: " . ($info[2] ?? 'unknown database error')
+        );
     }
 
     /**
@@ -83,17 +116,27 @@ class SeedRoles extends Migration
         $driver = $this->db->getAttribute(\PDO::ATTR_DRIVER_NAME);
 
         if ($driver === 'sqlite') {
-            $this->db->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_name ON roles(name)");
+            if ($this->db->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_name ON roles(name)") === false) {
+                $this->failed('create the unique index on roles(name)');
+            }
             return;
         }
 
+        // Both error modes have to be handled: exception mode throws, silent
+        // mode returns false and leaves the code on the handle.
         try {
-            $this->db->exec("CREATE UNIQUE INDEX idx_roles_name ON roles(name)");
-        } catch (\PDOException $e) {
-            // 1061: duplicate key name — the index is already there
-            if (($e->errorInfo[1] ?? null) !== 1061) {
-                throw $e;
+            if ($this->db->exec("CREATE UNIQUE INDEX idx_roles_name ON roles(name)") !== false) {
+                return;
             }
+
+            $code = $this->db->errorInfo()[1] ?? null;
+        } catch (\PDOException $e) {
+            $code = $e->errorInfo[1] ?? null;
+        }
+
+        // 1061: duplicate key name — the index is already there
+        if ((int) $code !== 1061) {
+            $this->failed('create the unique index on roles(name)');
         }
     }
 

--- a/tests/Integration/SeedRolesMysqlTest.php
+++ b/tests/Integration/SeedRolesMysqlTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/database/migrations/2025_09_03_000001_seed_roles.php';
+
+/**
+ * SeedRoles on MySQL Test
+ *
+ * The migration's statements have to be valid on MySQL, not only on SQLite.
+ * A dialect mistake in a migration is invisible until someone migrates on the
+ * other driver, which is exactly how it reached main.
+ *
+ * The migration runs against a TEMPORARY `roles` table: for the length of the
+ * connection it shadows the real one, so the developer database is untouched.
+ *
+ * @package Tests\Integration
+ */
+class SeedRolesMysqlTest extends TestCase
+{
+    /** @var \PDO */
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Taken from the environment only — no connection details are spelled
+        // out here. docker-compose exports these to the app container; without
+        // them there is nothing to connect to and the test skips.
+        $host = getenv('DB_HOST');
+        $name = getenv('DB_NAME');
+        $user = getenv('DB_USER');
+        $pass = getenv('DB_PASS');
+
+        if ($host === false || $name === false || $user === false) {
+            $this->markTestSkipped('DB_HOST/DB_NAME/DB_USER are not set: no MySQL to test against.');
+        }
+
+        try {
+            $this->pdo = new \PDO(
+                "mysql:host={$host};dbname={$name};charset=utf8mb4",
+                $user,
+                $pass,
+                [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_TIMEOUT => 3]
+            );
+        } catch (\PDOException $e) {
+            $this->markTestSkipped('MySQL not reachable: ' . $e->getMessage());
+        }
+
+        // Shadows the real table for this connection only
+        $this->pdo->exec("CREATE TEMPORARY TABLE roles (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(50) NOT NULL,
+            description VARCHAR(255) DEFAULT NULL,
+            level INT NOT NULL DEFAULT 0
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    }
+
+    private function roleNames(): array
+    {
+        $names = $this->pdo->query("SELECT name FROM roles ORDER BY name")->fetchAll(\PDO::FETCH_COLUMN);
+
+        return $names;
+    }
+
+    public function testUpSeedsTheDefaultRolesOnMysql()
+    {
+        (new \SeedRoles($this->pdo))->up();
+
+        $this->assertEquals(['admin', 'author', 'editor', 'subscriber'], $this->roleNames());
+    }
+
+    public function testUpIsIdempotentOnMysql()
+    {
+        $migration = new \SeedRoles($this->pdo);
+        $migration->up();
+        $migration->up();
+
+        $this->assertCount(4, $this->roleNames(), 'Re-running the migration must not duplicate roles');
+    }
+
+    public function testUpRemovesPreExistingDuplicatesOnMysql()
+    {
+        // The state an earlier double-seeding left behind, which the migration
+        // is meant to clean up before enforcing uniqueness.
+        $this->pdo->exec("INSERT INTO roles (name, description, level) VALUES
+            ('admin', 'first', 4), ('admin', 'duplicate', 4)");
+
+        (new \SeedRoles($this->pdo))->up();
+
+        $this->assertCount(4, $this->roleNames());
+    }
+}

--- a/tests/Unit/Database/MigrationMethodCallsTest.php
+++ b/tests/Unit/Database/MigrationMethodCallsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Migration method calls Test
+ *
+ * A migration that calls a method its class does not have fatals the moment
+ * that branch runs — and a driver-specific branch only runs on that driver, so
+ * the mistake stays invisible until someone migrates on the other one.
+ *
+ * @package Tests\Unit\Database
+ */
+class MigrationMethodCallsTest extends TestCase
+{
+    /**
+     * @return array<int, array{0: string, 1: string}> [file, class] pairs
+     */
+    private function migrationClasses(): array
+    {
+        $found = [];
+
+        foreach (glob(dirname(__DIR__, 3) . '/database/migrations/*.php') as $file) {
+            $source = file_get_contents($file);
+
+            if (!preg_match('/^class\s+([A-Za-z0-9_]+)/m', $source, $m)) {
+                continue;
+            }
+
+            require_once $file;
+            $found[] = [$file, $m[1]];
+        }
+
+        return $found;
+    }
+
+    public function testEveryMigrationCallsOnlyMethodsThatExist()
+    {
+        $migrations = $this->migrationClasses();
+
+        $this->assertNotEmpty($migrations, 'No migrations were resolved — the test would prove nothing');
+
+        $offenders = [];
+
+        foreach ($migrations as [$file, $class]) {
+            $this->assertTrue(class_exists($class), "Class {$class} not defined by " . basename($file));
+
+            $source = file_get_contents($file);
+            preg_match_all('/\$this->([A-Za-z0-9_]+)\s*\(/', $source, $calls);
+
+            foreach (array_unique($calls[1]) as $method) {
+                if (!method_exists($class, $method)) {
+                    $offenders[] = basename($file) . ": \$this->{$method}() does not exist on {$class}";
+                }
+            }
+        }
+
+        $this->assertSame([], $offenders, "Migrations call methods that do not exist:\n" . implode("\n", $offenders));
+    }
+
+    public function testMigrationBaseClassHasNoExecMethod()
+    {
+        // Guards the assumption the test above relies on: `exec` is the easy
+        // typo for `execute`, and it only exists on the PDO handle ($this->db).
+        $base = new ReflectionClass(\App\Core\Database\Migration::class);
+
+        $this->assertFalse($base->hasMethod('exec'));
+        $this->assertTrue($base->hasMethod('execute'));
+    }
+}

--- a/tests/Unit/Database/SeedRolesTest.php
+++ b/tests/Unit/Database/SeedRolesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Database;
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 3) . '/database/migrations/2025_09_03_000001_seed_roles.php';
+
+/**
+ * SeedRoles Test
+ *
+ * Covers the SQLite path of the migration, so its behaviour is guarded in any
+ * environment — the MySQL counterpart needs a server and skips without one.
+ *
+ * @package Tests\Unit\Database
+ */
+class SeedRolesTest extends TestCase
+{
+    private function connection(int $errorMode = \PDO::ERRMODE_EXCEPTION): \PDO
+    {
+        $pdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => $errorMode]);
+
+        return $pdo;
+    }
+
+    private function createRolesTable(\PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE roles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name VARCHAR(50) NOT NULL,
+            description VARCHAR(255) DEFAULT NULL,
+            level INTEGER NOT NULL DEFAULT 0
+        )");
+    }
+
+    private function roleNames(\PDO $pdo): array
+    {
+        return $pdo->query("SELECT name FROM roles ORDER BY name")->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    public function testUpSeedsTheDefaultRoles()
+    {
+        $pdo = $this->connection();
+        $this->createRolesTable($pdo);
+
+        (new \SeedRoles($pdo))->up();
+
+        $this->assertEquals(['admin', 'author', 'editor', 'subscriber'], $this->roleNames($pdo));
+    }
+
+    public function testUpIsIdempotent()
+    {
+        $pdo = $this->connection();
+        $this->createRolesTable($pdo);
+
+        $migration = new \SeedRoles($pdo);
+        $migration->up();
+        $migration->up();
+
+        $this->assertCount(4, $this->roleNames($pdo));
+    }
+
+    public function testUpRemovesPreExistingDuplicates()
+    {
+        $pdo = $this->connection();
+        $this->createRolesTable($pdo);
+        $pdo->exec("INSERT INTO roles (name, description, level) VALUES
+            ('admin', 'first', 4), ('admin', 'duplicate', 4)");
+
+        (new \SeedRoles($pdo))->up();
+
+        $this->assertCount(4, $this->roleNames($pdo));
+    }
+
+    public function testUpCreatesTheUniqueNameIndex()
+    {
+        $pdo = $this->connection();
+        $this->createRolesTable($pdo);
+
+        (new \SeedRoles($pdo))->up();
+
+        $this->expectException(\PDOException::class);
+        $pdo->exec("INSERT INTO roles (name, description, level) VALUES ('admin', 'second admin', 4)");
+    }
+
+    public function testAFailedStatementRaisesAnExceptionEvenOnASilentConnection()
+    {
+        // PHP 7.4 — still allowed by composer.json — defaults PDO to
+        // ERRMODE_SILENT, and InstallController builds its connection without
+        // options. A failing statement must surface as an Exception that
+        // MigrationRunner's catch(\Exception) can report, not as an Error
+        // raised by calling a method on false.
+        $pdo = $this->connection(\PDO::ERRMODE_SILENT);
+        // roles deliberately not created
+
+        $this->expectException(\Exception::class);
+
+        (new \SeedRoles($pdo))->up();
+    }
+}


### PR DESCRIPTION
Closes #22

Two migrations were written so that only their SQLite path ever worked. On MySQL the run died at the first of them and every migration after it never ran — which is why a fresh clone could not be migrated at all. One commit per defect.

## `create_media_tables` — `$this->exec()` does not exist

`Migration` defines `execute()`; `exec()` exists only on the PDO handle. The MySQL branch called `$this->exec(...)`:

```
Fatal error: Call to undefined method CreateMediaTables::exec()
```

The SQLite branch a few lines above already used `$this->db->exec(...)` correctly — which is exactly why it survived: the failing line only runs on the driver the test suite does not use.

## `seed_roles` — three SQLite-only statements

- `DELETE FROM roles WHERE id NOT IN (SELECT MIN(id) FROM roles GROUP BY name)` reads the table it deletes from. MySQL rejects that (error 1093; 1137 on a temporary table). Now it reads the ids to keep first and deletes by explicit list — accepted by both drivers.
- `CREATE UNIQUE INDEX IF NOT EXISTS` has no MySQL equivalent, so there the duplicate-key error (1061) is what reports the index is already in place.
- `INSERT OR IGNORE` is not MySQL syntax. Replaced with check-then-insert rather than MySQL's `INSERT IGNORE`, because `IGNORE` only suppresses a constraint violation: it would silently duplicate rows anywhere the unique index could not be created — precisely the mess this migration exists to clean up.

The driver is read from the connection (`PDO::ATTR_DRIVER_NAME`) rather than the `DB_DRIVER` constant, which is not necessarily the connection the migration was handed.

## Tests

- **`tests/Unit/Database/MigrationMethodCallsTest.php`** walks all 26 migrations, resolves every `$this->x()` call against its class, and fails on any that does not exist. Catches this whole class of bug on any driver, with no database. Verified RED first: it reported exactly `create_media_tables.php: $this->exec() does not exist on CreateMediaTables` and nothing else.
- **`tests/Integration/SeedRolesMysqlTest.php`** runs the real migration against MySQL. It creates a `TEMPORARY roles` table, which shadows the real one for that connection only, so the developer database is untouched (verified: real table still had its 4 rows afterwards). Covers seeding, idempotency on re-run, and cleanup of pre-existing duplicates. Verified RED first: all three errored on the self-referencing DELETE. Connection details come from the environment only — the test skips when they are absent.

## Verification

The issue's own repro, end to end:

```
DROP DATABASE swcms; CREATE DATABASE swcms;
php database/migrate.php up
```

→ **all 26 migrations applied, zero errors** (previously the run died at `create_media_tables` and, once that was hand-patched, again at `seed_roles`). A second run reports every migration as `[SKIP]`. Roles seeded correctly with the unique index in place (`Non_unique=0`), and the app serves 200 on `/` and `/auth/login` afterwards.

Also checked the SQLite path still behaves: seeding, idempotency and duplicate removal all correct on an in-memory database, so the fix is not a MySQL-only swap.

Suites: 280 Unit + 50 Integration, 0 errors. `phpcs` on the changed migration reports the same 2 errors / 1 warning as it does on `main` and as every other migration in this project does (no namespace, header block) — no new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)