### PR TITLE
Fix comment isolation between articles and pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
 
       - name: Run the test suite
         env:
+          COMMENTS_MYSQL_ADMIN_DSN: 'mysql:host=127.0.0.1;port=3306'
+          COMMENTS_MYSQL_USER: root
+          COMMENTS_MYSQL_PASSWORD: root_password
           DB_DRIVER: mysql
           DB_HOST: 127.0.0.1
           DB_PORT: 3306

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
 
       - name: Run the test suite
         env:
+          COMMENTS_MYSQL_ADMIN_DSN: 'mysql:host=127.0.0.1;port=3306'
+          COMMENTS_MYSQL_USER: root
+          COMMENTS_MYSQL_PASSWORD: root_password
           DB_DRIVER: mysql
           DB_HOST: 127.0.0.1
           DB_PORT: 3306

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ php database/migrate.php down
 php database/migrate.php up 2025_06_19_000010_create_users_table.php
 ```
 
+For the comment association upgrade (#40), see [migration and legacy data handling](docs/comment-content-migration.md).
+
 ### Plugin Development
 
 swCMS features a powerful plugin system with hooks and filters:

--- a/app/controllers/Frontend/CommentController.php
+++ b/app/controllers/Frontend/CommentController.php
@@ -18,6 +18,23 @@ class CommentController extends BaseController
         $this->commentModel = new Comments();
     }
 
+    /** Blank hidden fields are emitted by existing themes; any other invalid value is rejected. */
+    private function parseContentTarget($postId, $pageId): ?array
+    {
+        $target = [];
+        foreach (['post_id' => $postId, 'page_id' => $pageId] as $key => $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+            $id = filter_var($value, FILTER_VALIDATE_INT);
+            if ($id === false || $id < 1) {
+                return null;
+            }
+            $target[$key] = $id;
+        }
+        return count($target) === 1 ? $target : null;
+    }
+
     /**
      * Handle comment submission
      */
@@ -39,8 +56,12 @@ class CommentController extends BaseController
             }
 
             // Get and validate input data
-            $postId = filter_input(INPUT_POST, 'post_id', FILTER_VALIDATE_INT);
-            $pageId = filter_input(INPUT_POST, 'page_id', FILTER_VALIDATE_INT);
+            $target = $this->parseContentTarget(
+                filter_input(INPUT_POST, 'post_id'),
+                filter_input(INPUT_POST, 'page_id')
+            );
+            $postId = $target['post_id'] ?? null;
+            $pageId = $target['page_id'] ?? null;
             $parentId = filter_input(INPUT_POST, 'parent_id', FILTER_VALIDATE_INT); // For replies
             $content = trim(htmlspecialchars(filter_input(INPUT_POST, 'content', FILTER_UNSAFE_RAW) ?? '', ENT_QUOTES, 'UTF-8'));
             $authorName = trim(htmlspecialchars(filter_input(INPUT_POST, 'author_name', FILTER_UNSAFE_RAW) ?? '', ENT_QUOTES, 'UTF-8'));
@@ -53,8 +74,8 @@ class CommentController extends BaseController
                 return;
             }
 
-            if (!$postId && !$pageId) {
-                SessionHelper::setFlashMessage('ID post o pagina richiesto', 'error');
+            if ($target === null) {
+                SessionHelper::setFlashMessage('Specificare un solo ID valido di articolo o pagina', 'error');
                 RedirectHelper::redirectLocal($this->getParam('redirect_url', '/', 'POST'));
                 return;
             }
@@ -108,7 +129,7 @@ class CommentController extends BaseController
             if ($postId) {
                 $commentData['post_id'] = $postId;
             } else {
-                $commentData['post_id'] = $pageId; // In this implementation, we use post_id for both posts and pages
+                $commentData['page_id'] = $pageId;
             }
 
             // Set author information
@@ -162,14 +183,18 @@ class CommentController extends BaseController
         header('Content-Type: application/json');
 
         try {
-            $postId = filter_input(INPUT_GET, 'post_id', FILTER_VALIDATE_INT);
-            $pageId = filter_input(INPUT_GET, 'page_id', FILTER_VALIDATE_INT);
-            $page = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT) ?: 1;
+            $target = $this->parseContentTarget(
+                filter_input(INPUT_GET, 'post_id'),
+                filter_input(INPUT_GET, 'page_id')
+            );
+            $postId = $target['post_id'] ?? null;
+            $pageId = $target['page_id'] ?? null;
+            $page = max(1, filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT) ?: 1);
             $limit = 10;
             $offset = ($page - 1) * $limit;
 
-            if (!$postId && !$pageId) {
-                echo json_encode(['error' => 'Post ID or Page ID required']);
+            if ($target === null) {
+                echo json_encode(['error' => 'Exactly one valid Post ID or Page ID is required']);
                 return;
             }
 
@@ -189,8 +214,8 @@ class CommentController extends BaseController
             }
 
             // Get approved comments
-            $comments = $this->commentModel->getApprovedForPost($contentId, $limit, $offset);
-            $totalComments = $this->commentModel->countApprovedForPost($contentId);
+            $comments = $this->commentModel->getApprovedForPost($contentId, $limit, $offset, $postId ? 'post' : 'page');
+            $totalComments = $this->commentModel->countApprovedForPost($contentId, $postId ? 'post' : 'page');
 
             echo json_encode([
                 'comments' => $comments,

--- a/app/controllers/Frontend/PageController.php
+++ b/app/controllers/Frontend/PageController.php
@@ -70,8 +70,8 @@ class PageController extends BaseController
             $offset = ($currentPage - 1) * $limit;
 
             // Use hierarchical comments for better reply structure
-            $comments = $this->commentModel->getApprovedHierarchicalForPost($page['id'], $limit, $offset);
-            $totalComments = $this->commentModel->countApprovedForPost($page['id']);
+            $comments = $this->commentModel->getApprovedHierarchicalForPage($page['id'], $limit, $offset);
+            $totalComments = $this->commentModel->countApprovedForPage($page['id']);
             $totalPages = ceil($totalComments / $limit);
         }
 

--- a/app/models/Comments.php
+++ b/app/models/Comments.php
@@ -8,9 +8,10 @@ class Comments extends Model
 {
     protected $table = 'comments';
 
-    public function __construct($params = [])
+    public function __construct(\PDO $pdo = null)
     {
-        parent::__construct($params);
+        $this->db = $pdo ?? \App\Core\Database\Database::getInstance();
+        $this->hookSystem = \App\Core\HookSystem::getInstance();
     }
 
     /**
@@ -19,12 +20,15 @@ class Comments extends Model
     public function getAll($status = null)
     {
         $sql = "SELECT c.*, 
-                       p.title as post_title,
+                       COALESCE(p.title, pg.title) as post_title,
+                       CASE WHEN c.post_id IS NOT NULL THEN 'post'
+                            WHEN c.page_id IS NOT NULL THEN 'page' ELSE 'unresolved' END as content_type,
                        u.username as user_username,
                        u.display_name as user_display_name,
                        u.email as user_email
                 FROM comments c 
                 LEFT JOIN posts p ON c.post_id = p.id
+                LEFT JOIN pages pg ON c.page_id = pg.id
                 LEFT JOIN users u ON c.user_id = u.id";
         if ($status !== null) {
             $sql .= " WHERE c.status = :status";
@@ -47,7 +51,9 @@ class Comments extends Model
     public function getAllHierarchical($status = null)
     {
         $sql = "SELECT c.*, 
-                       p.title as post_title,
+                       COALESCE(p.title, pg.title) as post_title,
+                       CASE WHEN c.post_id IS NOT NULL THEN 'post'
+                            WHEN c.page_id IS NOT NULL THEN 'page' ELSE 'unresolved' END as content_type,
                        u.username as user_username,
                        u.display_name as user_display_name,
                        u.email as user_email,
@@ -55,8 +61,11 @@ class Comments extends Model
                        parent_c.author_name as parent_author_name
                 FROM comments c 
                 LEFT JOIN posts p ON c.post_id = p.id
+                LEFT JOIN pages pg ON c.page_id = pg.id
                 LEFT JOIN users u ON c.user_id = u.id
-                LEFT JOIN comments parent_c ON c.parent_id = parent_c.id";
+                LEFT JOIN comments parent_c ON c.parent_id = parent_c.id
+                    AND ((c.post_id = parent_c.post_id AND c.page_id IS NULL AND parent_c.page_id IS NULL)
+                      OR (c.page_id = parent_c.page_id AND c.post_id IS NULL AND parent_c.post_id IS NULL))";
         if ($status !== null) {
             $sql .= " WHERE c.status = :status";
         }
@@ -71,7 +80,43 @@ class Comments extends Model
         $allComments = $stmt->fetchAll($this->db::FETCH_ASSOC);
 
         // For admin, show all comments in hierarchy but don't limit
-        return $this->buildAdminCommentTree($allComments);
+        return $this->buildAdminCommentTree($this->normalizeAdminParents($allComments));
+    }
+
+    private function normalizeAdminParents(array $comments): array
+    {
+        $byId = array_column($comments, null, 'id');
+        foreach ($comments as &$comment) {
+            $seen = [$comment['id'] => true];
+            $cursor = $comment;
+            while ($cursor['parent_id'] !== null) {
+                $parent = $byId[$cursor['parent_id']] ?? null;
+                if (!$parent || !$this->sameContent($cursor, $parent) || isset($seen[$parent['id']])) {
+                    $comment['parent_id'] = null;
+                    break;
+                }
+                $seen[$parent['id']] = true;
+                $cursor = $parent;
+            }
+        }
+        unset($comment);
+        return $comments;
+    }
+
+    private function sameContent(array $left, array $right): bool
+    {
+        return (!empty($left['post_id']) && $left['post_id'] == $right['post_id']
+                && empty($left['page_id']) && empty($right['page_id']))
+            || (!empty($left['page_id']) && $left['page_id'] == $right['page_id']
+                && empty($left['post_id']) && empty($right['post_id']));
+    }
+
+    private function contentColumn(string $type): string
+    {
+        if (!in_array($type, ['post', 'page'], true)) {
+            throw new \InvalidArgumentException('Invalid comment content type');
+        }
+        return $type . '_id';
     }
 
     /**
@@ -137,6 +182,21 @@ class Comments extends Model
         return $count;
     }
 
+    public function getApprovedForPage($pageId, $limit = 20, $offset = 0)
+    {
+        return $this->getApprovedForPost($pageId, $limit, $offset, 'page');
+    }
+
+    public function getApprovedHierarchicalForPage($pageId, $limit = 20, $offset = 0)
+    {
+        return $this->getApprovedHierarchicalForPost($pageId, $limit, $offset, 'page');
+    }
+
+    public function countApprovedForPage($pageId)
+    {
+        return $this->countApprovedForPost($pageId, 'page');
+    }
+
     /**
      * Get approved comments for a post
      *
@@ -145,13 +205,14 @@ class Comments extends Model
      * @param int $offset Offset for pagination
      * @return array List of comments
      */
-    public function getApprovedForPost($postId, $limit = 20, $offset = 0)
+    public function getApprovedForPost($postId, $limit = 20, $offset = 0, $type = 'post')
     {
+        $column = $this->contentColumn($type);
         $sql = "SELECT c.*, u.display_name as user_display_name, u.username
                 FROM comments c 
                 LEFT JOIN users u ON c.user_id = u.id
-                WHERE c.post_id = :post_id AND c.status = 'approved'
-                ORDER BY c.created_at ASC
+                WHERE c.{$column} = :post_id AND c.status = 'approved'
+                ORDER BY c.created_at ASC, c.id ASC
                 LIMIT :limit OFFSET :offset";
 
         $stmt = $this->db->prepare($sql);
@@ -171,14 +232,15 @@ class Comments extends Model
      * @param int $offset Offset for pagination
      * @return array Hierarchical list of comments with replies
      */
-    public function getApprovedHierarchicalForPost($postId, $limit = 20, $offset = 0)
+    public function getApprovedHierarchicalForPost($postId, $limit = 20, $offset = 0, $type = 'post')
     {
+        $column = $this->contentColumn($type);
         // Get all approved comments for the post
         $sql = "SELECT c.*, u.display_name as user_display_name, u.username
                 FROM comments c 
                 LEFT JOIN users u ON c.user_id = u.id
-                WHERE c.post_id = :post_id AND c.status = 'approved'
-                ORDER BY c.parent_id IS NULL DESC, c.created_at ASC";
+                WHERE c.{$column} = :post_id AND c.status = 'approved'
+                ORDER BY c.parent_id IS NULL DESC, c.created_at ASC, c.id ASC";
 
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':post_id', $postId, \PDO::PARAM_INT);
@@ -241,8 +303,11 @@ class Comments extends Model
         $sql = "SELECT c.*, u.display_name as user_display_name, u.username
                 FROM comments c 
                 LEFT JOIN users u ON c.user_id = u.id
+                INNER JOIN comments parent_c ON parent_c.id = c.parent_id
+                    AND ((c.post_id = parent_c.post_id AND c.page_id IS NULL AND parent_c.page_id IS NULL)
+                      OR (c.page_id = parent_c.page_id AND c.post_id IS NULL AND parent_c.post_id IS NULL))
                 WHERE c.parent_id = :parent_id AND c.status = 'approved'
-                ORDER BY c.created_at ASC";
+                ORDER BY c.created_at ASC, c.id ASC";
 
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':parent_id', $parentId, \PDO::PARAM_INT);
@@ -289,12 +354,21 @@ class Comments extends Model
 
         // Verify parent comment exists and is approved
         $parentComment = $this->getById($data['parent_id']);
-        if (!$parentComment || $parentComment['status'] !== 'approved') {
+        if (
+            !$parentComment || $parentComment['status'] !== 'approved'
+            || !empty($parentComment['legacy_post_id'])
+        ) {
             return false;
         }
 
-        // Use the same post_id as parent comment
+        // Admin replies can omit the target; public replies must match the submitted target.
+        if (array_key_exists('post_id', $data) || array_key_exists('page_id', $data)) {
+            if (!$this->sameContent($data, $parentComment)) {
+                return false;
+            }
+        }
         $data['post_id'] = $parentComment['post_id'];
+        $data['page_id'] = $parentComment['page_id'];
 
         return $this->createComment($data);
     }
@@ -305,9 +379,10 @@ class Comments extends Model
      * @param int $postId The post ID
      * @return int Number of approved comments
      */
-    public function countApprovedForPost($postId)
+    public function countApprovedForPost($postId, $type = 'post')
     {
-        $sql = "SELECT COUNT(*) FROM comments WHERE post_id = :post_id AND status = 'approved'";
+        $column = $this->contentColumn($type);
+        $sql = "SELECT COUNT(*) FROM comments WHERE {$column} = :post_id AND status = 'approved'";
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':post_id', $postId, \PDO::PARAM_INT);
         $stmt->execute();
@@ -323,6 +398,28 @@ class Comments extends Model
      */
     public function createComment($data)
     {
+        $postId = $data['post_id'] ?? null;
+        $pageId = $data['page_id'] ?? null;
+        if (($postId === null) === ($pageId === null) || !empty($data['legacy_post_id'])) {
+            return false;
+        }
+        $id = $postId ?? $pageId;
+        if (filter_var($id, FILTER_VALIDATE_INT) === false || $id < 1) {
+            return false;
+        }
+        $table = $postId !== null ? 'posts' : 'pages';
+        $stmt = $this->db->prepare("SELECT id FROM {$table} WHERE id = :id");
+        $stmt->execute(['id' => $id]);
+        if (!$stmt->fetchColumn()) {
+            return false;
+        }
+        if (!empty($data['parent_id'])) {
+            $parent = $this->getById($data['parent_id']);
+            if (!$parent || $parent['status'] !== 'approved' || !$this->sameContent($data, $parent)) {
+                return false;
+            }
+        }
+
         // Sanitize content - remove HTML tags
         $data['content'] = strip_tags($data['content']);
 
@@ -339,12 +436,50 @@ class Comments extends Model
         return $this->insert($data);
     }
 
+    public function delete($id)
+    {
+        $record = $this->getById($id);
+        if (!$record) {
+            return false;
+        }
+        $this->fireModelHook('before_delete', $record, $id);
+        $allow = $this->hookSystem->applyFilters('model_allow_delete', true, $this->table, $id, $record);
+        $allow = $this->hookSystem->applyFilters('comments_allow_delete', $allow, $id, $record);
+        if (!$allow) {
+            return false;
+        }
+        $ownsTransaction = !$this->db->inTransaction();
+        if ($ownsTransaction) {
+            $this->db->beginTransaction();
+        }
+        try {
+            $this->query('UPDATE comments SET parent_id = NULL WHERE parent_id = :id', [':id' => $id]);
+            $this->query('DELETE FROM comments WHERE id = :id', [':id' => $id]);
+            if ($ownsTransaction) {
+                $this->db->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($ownsTransaction && $this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
+        }
+        $this->fireModelHook('after_delete', $record, $id);
+        return true;
+    }
+
     /**
      * Update comment status
      */
     public function updateStatus($id, $status)
     {
+        if (!in_array($status, ['approved', 'pending', 'spam', 'trash'], true)) {
+            return false;
+        }
         $sql = "UPDATE comments SET status = :status WHERE id = :id";
+        if ($status === 'approved') {
+            $sql .= " AND legacy_post_id IS NULL";
+        }
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':status', $status);
         $stmt->bindValue(':id', $id);
@@ -406,6 +541,6 @@ class Comments extends Model
      */
     protected function getAllowedOrderByColumns()
     {
-        return ['id', 'post_id', 'author_name', 'author_email', 'status', 'parent_id', 'user_id', 'created_at'];
+        return ['id', 'post_id', 'page_id', 'legacy_post_id', 'author_name', 'author_email', 'status', 'parent_id', 'user_id', 'created_at'];
     }
 }

--- a/app/views/admin/comments/index.tpl
+++ b/app/views/admin/comments/index.tpl
@@ -83,12 +83,16 @@
                                     {/if}
                                     <div class="mb-2">
                                         <p class="mb-1">{$comment.content|escape|nl2br}</p>
-                                        <small class="text-muted">Post: <strong>{$comment.post_title|escape}</strong></small>
+                                        <small class="text-muted">{if $comment.content_type == 'unresolved'}
+                                            <span class="badge bg-warning text-dark">Da verificare — ID originale {$comment.legacy_post_id}</span>
+                                        {else}
+                                            {if $comment.content_type == 'page'}Pagina{else}Articolo{/if}: {$comment.post_title|escape}
+                                        {/if}</small>
                                     </div>
                                 </div>
                                 <div class="col-md-4 text-end">
                                     <div class="btn-group-vertical btn-group-sm" role="group">
-                                        {if $comment.status != 'approved'}
+                                        {if $comment.status != 'approved' && $comment.content_type != 'unresolved'}
                                             <form method="POST" action="/admin/comments/approve" class="d-inline">
                                                 <input type="hidden" name="csrf_token" value="{$csrf_token}">
                                                 <input type="hidden" name="id" value="{$comment.id}">
@@ -106,7 +110,7 @@
                                                 </button>
                                             </form>
                                         {/if}
-                                        {if $comment.status == 'approved'}
+                                        {if $comment.status == 'approved' && $comment.content_type != 'unresolved'}
                                             <a href="/admin/comments/reply?id={$comment.id}" class="btn btn-outline-primary" title="Reply">
                                                 <i class="fa fa-reply"></i> Reply
                                             </a>
@@ -151,7 +155,7 @@
                     <th>Author</th>
                     <th>Email</th>
                     <th>Content</th>
-                    <th>Post</th>
+                    <th>Content</th>
                     <th>Status</th>
                     <th>Date</th>
                     <th>Actions</th>
@@ -201,7 +205,11 @@
                         {/if}
                     </td>
                     <td>{$comment.content|truncate:60|escape}</td>
-                    <td>{$comment.post_title|escape}</td>
+                    <td>{if $comment.content_type == 'unresolved'}
+                                            <span class="badge bg-warning text-dark">Da verificare — ID originale {$comment.legacy_post_id}</span>
+                                        {else}
+                                            {if $comment.content_type == 'page'}Pagina{else}Articolo{/if}: {$comment.post_title|escape}
+                                        {/if}</td>
                     <td>
                         {if $comment.status == 'approved'}<span class="badge bg-success">Approved</span>{/if}
                         {if $comment.status == 'pending'}<span class="badge bg-warning text-dark">Pending</span>{/if}
@@ -209,7 +217,7 @@
                     </td>
                     <td>{$comment.created_at|date_format:"%d/%m/%Y %H:%M"}</td>
                     <td>
-                        {if $comment.status != 'approved'}
+                        {if $comment.status != 'approved' && $comment.content_type != 'unresolved'}
                             <form method="POST" action="/admin/comments/approve" class="d-inline">
                                 <input type="hidden" name="csrf_token" value="{$csrf_token}">
                                 <input type="hidden" name="id" value="{$comment.id}">
@@ -223,7 +231,7 @@
                                 <button type="submit" class="btn btn-sm btn-outline-warning" title="Mark as Spam"><i class="fa fa-flag"></i></button>
                             </form>
                         {/if}
-                        {if $comment.status == 'approved'}
+                        {if $comment.status == 'approved' && $comment.content_type != 'unresolved'}
                             <a href="/admin/comments/reply?id={$comment.id}" class="btn btn-sm btn-outline-primary" title="Reply"><i class="fa fa-reply"></i></a>
                         {/if}
                         <form method="POST" action="/admin/comments/delete" class="d-inline" onsubmit="return confirm('Delete this comment?');">

--- a/database/migrations/2026_09_06_000001_separate_comment_content_references.php
+++ b/database/migrations/2026_09_06_000001_separate_comment_content_references.php
@@ -1,0 +1,185 @@
+<?php
+
+require_once __DIR__ . '/../../app/core/Database/Migration.php';
+
+use App\Core\Database\Migration;
+
+/**
+ * Keep exactly one of post_id, page_id or the unresolved legacy_post_id.
+ * Run with the application offline: MySQL DDL cannot be transactional.
+ */
+class SeparateCommentContentReferences extends Migration
+{
+    protected $db;
+
+    public function up()
+    {
+        if ($this->db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $this->upSqlite();
+        } else {
+            $this->upMysql();
+        }
+    }
+
+    private function targetCheck(): string
+    {
+        return '(CASE WHEN post_id IS NULL THEN 0 ELSE 1 END'
+            . ' + CASE WHEN page_id IS NULL THEN 0 ELSE 1 END'
+            . ' + CASE WHEN legacy_post_id IS NULL THEN 0 ELSE 1 END) = 1';
+    }
+
+    private function upSqlite(): void
+    {
+        $columns = $this->db->query('PRAGMA table_info(comments)')->fetchAll(PDO::FETCH_ASSOC);
+        if (in_array('page_id', array_column($columns, 'name'), true)) {
+            return;
+        }
+        if ($this->db->inTransaction()) {
+            throw new RuntimeException('Comment migration must run outside a transaction.');
+        }
+        $schema = $this->db->query("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'comments'")
+            ->fetchColumn();
+        $objects = $this->db->query("SELECT sql FROM sqlite_master
+            WHERE tbl_name = 'comments' AND type IN ('index', 'trigger') AND sql IS NOT NULL")
+            ->fetchAll(PDO::FETCH_COLUMN);
+        $foreignKeys = $this->db->query('PRAGMA foreign_key_list(comments)')->fetchAll(PDO::FETCH_ASSOC);
+        // Preserve custom columns, indexes, triggers and existing user/parent constraints.
+        $schema = preg_replace(
+            '/^(CREATE TABLE\s+)(?:IF NOT EXISTS\s+)?["`\[]?comments["`\]]?/i',
+            '$1comments_typed',
+            $schema,
+            1
+        );
+        $schema = preg_replace('/(["`\[]?post_id["`\]]?\s+\w+(?:\(\d+\))?)\s+NOT NULL/i', '$1', $schema, 1);
+        $schema = substr_replace(
+            $schema,
+            'page_id INTEGER DEFAULT NULL, legacy_post_id INTEGER DEFAULT NULL, ',
+            strpos($schema, '(') + 1,
+            0
+        );
+        $extra = ', CONSTRAINT chk_comments_target CHECK (' . $this->targetCheck() . ')'
+            . ', FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE';
+        if (!in_array('post_id', array_column($foreignKeys, 'from'), true)) {
+            $extra .= ', FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE';
+        }
+        $end = strrpos($schema, ')');
+        $schema = substr_replace($schema, $extra, $end, 0);
+        $foreignKeysEnabled = (int) $this->db->query('PRAGMA foreign_keys')->fetchColumn();
+        $this->db->exec('PRAGMA foreign_keys = OFF');
+        $this->db->beginTransaction();
+        try {
+            $sequence = $this->db->query("SELECT seq FROM sqlite_sequence WHERE name = 'comments'")->fetchColumn();
+            $this->db->exec($schema);
+            $names = array_map(fn($c) => '"' . str_replace('"', '""', $c['name']) . '"', $columns);
+            $select = array_map(function ($c) {
+                if ($c['name'] === 'post_id') {
+                    return 'CASE WHEN p.id IS NOT NULL AND pg.id IS NULL THEN c.post_id ELSE NULL END';
+                }
+                return 'c."' . str_replace('"', '""', $c['name']) . '"';
+            }, $columns);
+            $this->db->exec('INSERT INTO comments_typed (' . implode(', ', $names) . ', page_id, legacy_post_id)'
+                . ' SELECT ' . implode(', ', $select)
+                . ', CASE WHEN p.id IS NULL AND pg.id IS NOT NULL THEN c.post_id ELSE NULL END'
+                . ', CASE WHEN (p.id IS NULL AND pg.id IS NULL) OR (p.id IS NOT NULL AND pg.id IS NOT NULL)'
+                . ' THEN c.post_id ELSE NULL END'
+                . ' FROM comments c LEFT JOIN posts p ON p.id = c.post_id LEFT JOIN pages pg ON pg.id = c.post_id');
+            $this->db->exec('DROP TABLE comments');
+            $this->db->exec('ALTER TABLE comments_typed RENAME TO comments');
+            foreach ($objects as $sql) {
+                $this->db->exec($sql);
+            }
+            $this->db->exec('CREATE INDEX idx_comments_post_status ON comments(post_id, status, parent_id)');
+            $this->db->exec('CREATE INDEX idx_comments_page_status ON comments(page_id, status, parent_id)');
+            if ($sequence !== false) {
+                $stmt = $this->db->prepare("UPDATE sqlite_sequence SET seq = MAX(seq, :seq) WHERE name = 'comments'");
+                $stmt->execute(['seq' => (int) $sequence]);
+            }
+            $this->db->commit();
+        } catch (Throwable $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
+        } finally {
+            $this->db->exec('PRAGMA foreign_keys = ' . $foreignKeysEnabled);
+        }
+    }
+
+    private function upMysql(): void
+    {
+        $triggers = $this->db->query("SELECT TRIGGER_NAME FROM information_schema.TRIGGERS
+            WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = 'comments'")->fetchAll(PDO::FETCH_COLUMN);
+        if (
+            in_array('comments_target_insert', $triggers, true)
+            && in_array('comments_target_update', $triggers, true)
+        ) {
+            return;
+        }
+        $columns = $this->db->query('SHOW COLUMNS FROM comments')->fetchAll(PDO::FETCH_ASSOC);
+        if (!in_array('page_id', array_column($columns, 'Field'), true)) {
+            // Preserve the exact ID type (including UNSIGNED) used by this installation.
+            $postType = $this->db->query("SHOW COLUMNS FROM posts LIKE 'id'")->fetch(PDO::FETCH_ASSOC)['Type'];
+            $pageType = $this->db->query("SHOW COLUMNS FROM pages LIKE 'id'")->fetch(PDO::FETCH_ASSOC)['Type'];
+            $this->db->exec("ALTER TABLE comments MODIFY post_id {$postType} NULL,
+                ADD page_id {$pageType} NULL, ADD legacy_post_id {$postType} NULL");
+        }
+        // Multi-table UPDATE expressions read the original source ID; target assignment order is irrelevant.
+        $this->db->beginTransaction();
+        try {
+            $this->db->exec("UPDATE comments c
+                LEFT JOIN posts p ON p.id = c.post_id
+                LEFT JOIN pages pg ON pg.id = c.post_id
+                SET c.legacy_post_id = CASE
+                        WHEN (p.id IS NULL AND pg.id IS NULL) OR (p.id IS NOT NULL AND pg.id IS NOT NULL)
+                        THEN c.post_id ELSE NULL END,
+                    c.page_id = CASE WHEN p.id IS NULL AND pg.id IS NOT NULL THEN pg.id ELSE NULL END,
+                    c.post_id = CASE WHEN p.id IS NOT NULL AND pg.id IS NULL THEN p.id ELSE NULL END
+                WHERE c.page_id IS NULL AND c.legacy_post_id IS NULL");
+            $this->db->commit();
+        } catch (Throwable $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
+        }
+        $foreignColumns = $this->db->query("SELECT COLUMN_NAME FROM information_schema.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'comments' AND REFERENCED_TABLE_NAME IS NOT NULL")
+            ->fetchAll(PDO::FETCH_COLUMN);
+        $alter = [
+            'ADD INDEX idx_comments_post_status (post_id, status, parent_id)',
+            'ADD INDEX idx_comments_page_status (page_id, status, parent_id)',
+        ];
+        if (!in_array('post_id', $foreignColumns, true)) {
+            $alter[] = 'ADD CONSTRAINT fk_comments_post FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE';
+        }
+        if (!in_array('page_id', $foreignColumns, true)) {
+            $alter[] = 'ADD CONSTRAINT fk_comments_page FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE';
+        }
+        $indexes = $this->db->query('SHOW INDEX FROM comments')->fetchAll(PDO::FETCH_ASSOC);
+        $indexNames = array_column($indexes, 'Key_name');
+        $alter = array_filter($alter, function ($sql) use ($indexNames) {
+            return !preg_match('/ADD INDEX (\w+)/', $sql, $match) || !in_array($match[1], $indexNames, true);
+        });
+        if ($alter) {
+            $this->db->exec('ALTER TABLE comments ' . implode(', ', $alter));
+        }
+        // MySQL forbids CHECKs on columns participating in FK cascade actions.
+        // Equivalent BEFORE triggers enforce exclusivity without sacrificing typed cascades.
+        // https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html
+        $check = preg_replace('/\b(post_id|page_id|legacy_post_id)\b/', 'NEW.$1', $this->targetCheck());
+        foreach (['insert', 'update'] as $event) {
+            if (!in_array('comments_target_' . $event, $triggers, true)) {
+                $this->db->exec('CREATE TRIGGER comments_target_' . $event . ' BEFORE ' . strtoupper($event)
+                    . ' ON comments FOR EACH ROW BEGIN IF NOT (' . $check . ") THEN
+                        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'A comment must have exactly one content reference';
+                      END IF; END");
+            }
+        }
+    }
+
+    public function down()
+    {
+        // Flattening page/post references reintroduces collisions and can lose data through the old FK.
+        throw new RuntimeException('This migration cannot be reversed safely. Restore the pre-migration backup.');
+    }
+}

--- a/docs/comment-content-migration.md
+++ b/docs/comment-content-migration.md
@@ -1,0 +1,117 @@
+# Commenti separati per articoli e pagine (#40)
+
+La migrazione `2026_09_06_000001_separate_comment_content_references.php` introduce
+riferimenti distinti nella tabella `comments`:
+
+| Colonna valorizzata | Significato |
+| --- | --- |
+| `post_id` | ID di un articolo in `posts` |
+| `page_id` | ID di una pagina in `pages` |
+| `legacy_post_id` | ID originale di un commento storico da verificare |
+
+Esattamente una delle tre colonne deve essere valorizzata. Gli ID dei commenti,
+il testo, lo stato di moderazione, gli autori e i collegamenti `parent_id` esistenti
+sono conservati.
+
+## Aggiornamento
+
+1. Mettere il sito in manutenzione e fare un backup completo del database.
+2. Installare il codice aggiornato ed eseguire, prima di riaprire il sito:
+
+   ```sh
+   php database/migrate.php up 2026_09_06_000001_separate_comment_content_references.php
+   ```
+
+3. Verificare l'esito della migrazione e la lista Commenti in amministrazione.
+
+MySQL richiede i permessi `ALTER`, `INDEX`, `REFERENCES` e `TRIGGER`, oltre ai normali
+permessi sui dati. La migrazione usa chiavi esterne con `ON DELETE CASCADE` per
+entrambi i tipi di contenuto e indici `(post_id, status, parent_id)` e
+`(page_id, status, parent_id)`. SQLite usa un `CHECK` per l'esclusività del
+riferimento; MySQL usa due trigger `BEFORE INSERT/UPDATE`, poiché non consente un
+`CHECK` sulle colonne coinvolte nelle azioni referenziali delle chiavi esterne
+([documentazione MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html)).
+
+SQLite ricostruisce la tabella in una transazione conservando colonne aggiuntive,
+indici, trigger e vincoli preesistenti. Le connessioni SQLite devono abilitare
+`PRAGMA foreign_keys = ON`, come già fa il core. Su MySQL il DDL non è
+transazionale: non eseguire la migrazione mentre il sito riceve scritture.
+Un'esecuzione interrotta può essere rilanciata per completare indici e trigger.
+
+Il rollback automatico è intenzionalmente rifiutato: ricondurre i riferimenti a
+un singolo `post_id` ripristinerebbe il difetto e potrebbe perdere commenti di
+pagina. Per tornare al codice precedente ripristinare anche il backup precedente.
+
+## Dati storici
+
+La classificazione usa lo stato di `posts` e `pages` al momento della migrazione:
+
+- ID presente solo in `posts`: mantenuto in `post_id`.
+- ID presente solo in `pages`: spostato in `page_id`.
+- ID presente in entrambe, oppure in nessuna: spostato in `legacy_post_id`;
+  `post_id` e `page_id` diventano `NULL`.
+
+Non si deduce il tipo dal testo, dal commento padre o dalla presenza del vecchio
+vincolo verso `posts`. Un commento storico di pagina poteva essere stato salvato
+proprio grazie alla coincidenza con l'ID di un articolo.
+
+I commenti da verificare restano visibili in entrambe le viste amministrative,
+con il loro ID originale. Non compaiono nel frontend, nelle risposte pubbliche o
+nei conteggi per contenuto, anche se avevano stato `approved`. È possibile
+segnalarli come spam o eliminarli, ma non approvarli o aggiungere risposte prima
+di averne risolto l'associazione. Una successiva cancellazione di articolo o
+pagina non li elimina né li riclassifica automaticamente.
+
+Per elencarli:
+
+```sql
+SELECT id, legacy_post_id, parent_id, status, content
+FROM comments
+WHERE legacy_post_id IS NOT NULL
+ORDER BY legacy_post_id, id;
+```
+
+La risoluzione richiede una verifica manuale contro il backup o la sorgente
+WordPress. Dopo aver identificato il destinatario, aggiornare in un'unica
+istruzione il riferimento corretto e azzerare `legacy_post_id`. Per esempio,
+**solo dopo avere verificato che il commento 123 appartiene alla pagina 5**:
+
+```sql
+UPDATE comments
+SET page_id = 5, post_id = NULL, legacy_post_id = NULL, status = 'pending'
+WHERE id = 123 AND legacy_post_id = 5;
+```
+
+Risolvere esplicitamente ogni risposta nello stesso contenuto del padre;
+se il collegamento storico è errato, impostare `parent_id = NULL`. La migrazione
+non altera questi collegamenti. La vista gerarchica amministrativa mostra come
+radici i commenti con padre assente dal filtro, incompatibile o ciclico, evitando
+che scompaiano dalla moderazione; i riferimenti originali restano nel database.
+La successiva approvazione segue il normale flusso amministrativo.
+
+## API per plugin e importer
+
+Usare `Comments::createComment()` con **solo** `post_id` oppure **solo** `page_id`.
+`createReply()` verifica che un destinatario esplicito coincida con quello del
+padre approvato; se il destinatario è omesso, lo eredita dal padre (flusso admin).
+Un padre irrisolto è rifiutato. Anche `createComment()` valida `parent_id`.
+Non usare `insert()`/SQL diretto per saltare la validazione delle gerarchie.
+
+Le API `getApprovedForPost()`, `getApprovedHierarchicalForPost()` e
+`countApprovedForPost()` continuano a riferirsi agli articoli. Le pagine usano
+le corrispondenti API `*ForPage()`. Nei risultati amministrativi `post_title`
+resta come alias compatibile del titolo, con `content_type` pari a `post`, `page`
+o `unresolved`.
+
+## Verifica
+
+```sh
+DB_DRIVER=sqlite php vendor/bin/phpunit --do-not-cache-result \
+  tests/Integration/CommentContentIsolationTest.php
+```
+
+La matrice include SQLite e MySQL, con e senza i vincoli del vecchio schema.
+Per MySQL impostare `COMMENTS_MYSQL_ADMIN_DSN`, `COMMENTS_MYSQL_USER` e
+`COMMENTS_MYSQL_PASSWORD` su un server di test: ogni caso crea e rimuove un
+database dal nome casuale `swcms_comments_test_*`. Senza queste variabili i casi
+MySQL vengono saltati; CI e verifica release le forniscono esplicitamente.

--- a/tests/Fixtures/comment_request_input.php
+++ b/tests/Fixtures/comment_request_input.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Controllers\Frontend;
+
+// Loaded only inside isolated PHPUnit child processes: CLI has no SAPI request input.
+function filter_input($type, $name, $filter = FILTER_DEFAULT, $options = 0)
+{
+    $input = $type === INPUT_GET ? $_GET : $_POST;
+    return array_key_exists($name, $input) ? filter_var($input[$name], $filter, $options) : null;
+}

--- a/tests/Integration/CommentContentIsolationTest.php
+++ b/tests/Integration/CommentContentIsolationTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Comments;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . '/database/migrations/2026_09_06_000001_separate_comment_content_references.php';
+
+class CommentContentIsolationTest extends TestCase
+{
+    private $pdo;
+    private $admin;
+    private $databaseName;
+    private $model;
+
+    public static function databases(): array
+    {
+        return [['sqlite', false], ['sqlite', true], ['mysql', false], ['mysql', true]];
+    }
+
+    private function setupDatabase(string $driver, bool $legacyForeignKeys): void
+    {
+        if ($driver === 'sqlite') {
+            $this->pdo = new \PDO('sqlite::memory:');
+            $this->pdo->exec('PRAGMA foreign_keys = ON');
+            $id = 'INTEGER PRIMARY KEY AUTOINCREMENT';
+        } else {
+            // Explicit opt-in: create/drop only a randomly named, isolated test database.
+            $dsn = getenv('COMMENTS_MYSQL_ADMIN_DSN');
+            if (!$dsn) {
+                $this->markTestSkipped('Set COMMENTS_MYSQL_ADMIN_DSN to run isolated MySQL regression tests.');
+            }
+            $this->admin = new \PDO($dsn, getenv('COMMENTS_MYSQL_USER'), getenv('COMMENTS_MYSQL_PASSWORD'), [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+            $this->databaseName = 'swcms_comments_test_' . bin2hex(random_bytes(6));
+            $this->admin->exec('CREATE DATABASE `' . $this->databaseName . '`');
+            $this->pdo = $this->admin;
+            $this->pdo->exec('USE `' . $this->databaseName . '`');
+            $id = 'INT AUTO_INCREMENT PRIMARY KEY';
+        }
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC);
+        $this->pdo->exec("CREATE TABLE posts (id INT PRIMARY KEY, title VARCHAR(100), comments_enabled INT DEFAULT 1)");
+        $this->pdo->exec("CREATE TABLE pages (id INT PRIMARY KEY, title VARCHAR(100), comments_enabled INT DEFAULT 1)");
+        $this->pdo->exec("CREATE TABLE users (id INT PRIMARY KEY, username VARCHAR(50), display_name VARCHAR(50), email VARCHAR(100))");
+        $fks = $legacyForeignKeys ? ', FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
+            FOREIGN KEY (parent_id) REFERENCES comments(id) ON DELETE SET NULL,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL' : '';
+        $this->pdo->exec("CREATE TABLE comments (
+            id {$id}, post_id INT NOT NULL, author_name VARCHAR(50), author_email VARCHAR(100),
+            author_url VARCHAR(100), author_ip VARCHAR(100), content TEXT NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending', parent_id INT, user_id INT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, extension_field VARCHAR(30) DEFAULT 'preserved'
+            {$fks})");
+        $this->pdo->exec('CREATE INDEX legacy_comment_index ON comments(author_name)');
+        $this->pdo->exec("INSERT INTO posts (id, title) VALUES (5, 'Article 5'), (6, 'Article 6')");
+        $this->pdo->exec("INSERT INTO pages (id, title) VALUES (5, 'Page 5'), (7, 'Page 7')");
+        $this->model = new Comments($this->pdo);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->model = null;
+        if ($this->admin && $this->databaseName) {
+            $this->admin->exec('DROP DATABASE `' . $this->databaseName . '`');
+        }
+        $this->pdo = $this->admin = null;
+        parent::tearDown();
+    }
+
+    private function migrate(): void
+    {
+        (new \SeparateCommentContentReferences($this->pdo))->up();
+    }
+
+    private function comment(array $target, string $content = 'Comment', string $status = 'approved'): int
+    {
+        $id = $this->model->createComment($target + ['content' => $content, 'status' => $status]);
+        $this->assertNotFalse($id);
+        return (int) $id;
+    }
+
+    /** @dataProvider databases */
+    public function testMigrationPreservesAmbiguousAndOrphanedData(string $driver, bool $fks): void
+    {
+        $this->setupDatabase($driver, $fks);
+        $this->pdo->exec("INSERT INTO comments (id, post_id, content, status) VALUES
+            (1, 5, 'ambiguous', 'approved'), (2, 6, 'article only', 'approved')");
+        $this->pdo->exec("INSERT INTO comments (id, post_id, parent_id, content, status) VALUES
+            (3, 5, 1, 'ambiguous reply', 'approved')");
+        if (!$fks) {
+            $this->pdo->exec("INSERT INTO comments (id, post_id, content, status) VALUES
+                (4, 7, 'page only', 'approved'), (5, 99, 'orphaned', 'approved')");
+        }
+        $this->migrate();
+        $ambiguous = $this->model->getById(1);
+        $this->assertNull($ambiguous['post_id']);
+        $this->assertNull($ambiguous['page_id']);
+        $this->assertEquals(5, $ambiguous['legacy_post_id']);
+        $this->assertSame('approved', $ambiguous['status']);
+        $this->assertSame('preserved', $ambiguous['extension_field']);
+        $this->assertEquals(6, $this->model->getById(2)['post_id']);
+        $this->assertEquals(1, $this->model->getById(3)['parent_id']);
+        if (!$fks) {
+            $this->assertEquals(7, $this->model->getById(4)['page_id']);
+            $this->assertEquals(99, $this->model->getById(5)['legacy_post_id']);
+        }
+        $this->assertSame([], $this->model->getApprovedForPost(5));
+        $this->assertSame([], $this->model->getApprovedForPage(5));
+        $this->assertCount($fks ? 3 : 5, $this->model->getAllHierarchical());
+        $this->assertFalse($this->model->createReply(['parent_id' => 1, 'content' => 'ambiguous reply']));
+        $this->model->updateStatus(1, 'spam');
+        $this->model->updateStatus(1, 'approved');
+        $this->assertSame('spam', $this->model->getById(1)['status']);
+        // A rerun must not reinterpret unresolved data after one of the colliding targets disappears.
+        $this->pdo->exec('DELETE FROM pages WHERE id = 5');
+        $this->migrate();
+        $this->assertEquals(5, $this->model->getById(1)['legacy_post_id']);
+        $this->assertSame(0, $this->model->countApprovedForPost(5));
+        $this->assertTrue($this->model->delete(1));
+        $this->assertNull($this->model->getById(3)['parent_id']);
+    }
+
+    /** @dataProvider databases */
+    public function testIdenticalIdsHaveSeparateListsCountsTreesAndModeration(string $driver, bool $fks): void
+    {
+        $this->setupDatabase($driver, $fks);
+        $this->migrate();
+        $post = $this->comment(['post_id' => 5], 'Article root');
+        $page = $this->comment(['page_id' => 5], 'Page root');
+        $postReply = $this->model->createReply(['parent_id' => $post, 'content' => 'Article reply', 'status' => 'approved']);
+        $pageReply = $this->model->createReply(['parent_id' => $page, 'content' => 'Page reply', 'status' => 'approved']);
+        $pending = $this->comment(['page_id' => 5], 'Awaiting moderation', 'pending');
+        $this->assertSame(2, $this->model->countApprovedForPost(5));
+        $this->assertSame(2, $this->model->countApprovedForPage(5));
+        $this->assertEquals([$post, $postReply], array_column($this->model->getApprovedForPost(5), 'id'));
+        $this->assertEquals([$page, $pageReply], array_column($this->model->getApprovedForPage(5), 'id'));
+        $this->assertEquals([$pageReply], array_column($this->model->getApprovedForPage(5, 1, 1), 'id'));
+        $postTree = $this->model->getApprovedHierarchicalForPost(5);
+        $pageTree = $this->model->getApprovedHierarchicalForPage(5);
+        $this->assertCount(1, $postTree);
+        $this->assertCount(1, $pageTree);
+        $this->assertEquals($postReply, $postTree[0]['replies'][0]['id']);
+        $this->assertEquals($pageReply, $pageTree[0]['replies'][0]['id']);
+        $this->assertEquals([$pageReply], array_column($this->model->getReplies($page), 'id'));
+        $rows = array_column($this->model->getAll(), null, 'id');
+        $this->assertSame('Article 5', $rows[$post]['post_title']);
+        $this->assertSame('Page 5', $rows[$page]['post_title']);
+        $this->assertSame('page', $rows[$page]['content_type']);
+        $this->model->updateStatus($pending, 'approved');
+        $this->model->updateStatus($postReply, 'spam');
+        $this->assertSame(1, $this->model->countApprovedForPost(5));
+        $this->assertSame(3, $this->model->countApprovedForPage(5));
+        $this->assertTrue($this->model->delete($post));
+        $this->assertNull($this->model->getById($postReply)['parent_id']);
+        $this->assertSame(3, $this->model->countApprovedForPage(5));
+    }
+
+    /** @dataProvider databases */
+    public function testCrossContentRepliesAndInvalidTargetsAreRejected(string $driver, bool $fks): void
+    {
+        $this->setupDatabase($driver, $fks);
+        $this->migrate();
+        $post = $this->comment(['post_id' => 5]);
+        $page = $this->comment(['page_id' => 5]);
+        foreach (
+            [['post_id' => 5, 'parent_id' => $page], ['page_id' => 5, 'parent_id' => $post],
+            ['post_id' => 6, 'parent_id' => $post]] as $target
+        ) {
+            $this->assertFalse($this->model->createReply($target + ['content' => 'wrong parent']));
+            $this->assertFalse($this->model->createComment($target + ['content' => 'wrong parent']));
+        }
+        foreach (
+            [[], ['post_id' => 5, 'page_id' => 5], ['post_id' => -1], ['page_id' => 99],
+            ['post_id' => 5, 'legacy_post_id' => 5]] as $target
+        ) {
+            $this->assertFalse($this->model->createComment($target + ['content' => 'invalid']));
+        }
+        $this->assertFalse($this->model->createReply(['parent_id' => 999, 'content' => 'missing parent']));
+        $this->model->updateStatus($post, 'pending');
+        $this->assertFalse($this->model->createReply(['parent_id' => $post, 'content' => 'unapproved parent']));
+    }
+
+    /** @dataProvider databases */
+    public function testTypedForeignKeysCascadeOnlyTheSelectedContent(string $driver, bool $fks): void
+    {
+        $this->setupDatabase($driver, $fks);
+        $this->migrate();
+        $this->comment(['post_id' => 5]);
+        $page = $this->comment(['page_id' => 5]);
+        $pageOnly = $this->comment(['page_id' => 7]);
+        $this->pdo->exec('DELETE FROM posts WHERE id = 5');
+        $this->assertSame(0, $this->model->countApprovedForPost(5));
+        $this->assertEquals($page, $this->model->getById($page)['id']);
+        $this->comment(['post_id' => 6]);
+        $this->pdo->exec("INSERT INTO pages (id, title) VALUES (6, 'Page 6')");
+        $this->comment(['page_id' => 6]);
+        $this->pdo->exec('DELETE FROM pages WHERE id = 6');
+        $this->assertSame(1, $this->model->countApprovedForPost(6));
+        $this->assertSame(0, $this->model->countApprovedForPage(6));
+        $this->assertEquals($pageOnly, $this->model->getById($pageOnly)['id']);
+        if ($driver === 'sqlite') {
+            $this->assertSame([], $this->pdo->query('PRAGMA foreign_key_check')->fetchAll());
+        }
+    }
+
+    /** @dataProvider databases */
+    public function testDatabaseRejectsInvalidAssociationsOnInsertAndUpdate(string $driver, bool $fks): void
+    {
+        $this->setupDatabase($driver, $fks);
+        $this->migrate();
+        $id = $this->comment(['post_id' => 5]);
+        foreach (
+            [
+            "INSERT INTO comments (post_id, page_id, content) VALUES (5, 5, 'both')",
+            "INSERT INTO comments (content) VALUES ('no target')",
+            "INSERT INTO comments (page_id, content) VALUES (99, 'missing')",
+            "UPDATE comments SET page_id = 5 WHERE id = {$id}",
+            "UPDATE comments SET post_id = NULL WHERE id = {$id}",
+            ] as $sql
+        ) {
+            try {
+                $this->pdo->exec($sql);
+                $this->fail('Invalid association was accepted: ' . $sql);
+            } catch (\PDOException $e) {
+                $this->assertNotEmpty($e->getMessage());
+            }
+        }
+    }
+
+    /** @dataProvider databases */
+    public function testAdminKeepsFilteredAndInvalidLegacyRepliesVisible(string $driver, bool $fks): void
+    {
+        $this->setupDatabase($driver, $fks);
+        $this->migrate();
+        $post = $this->comment(['post_id' => 5]);
+        $page = $this->comment(['page_id' => 5]);
+        $pending = $this->comment(['post_id' => 5, 'parent_id' => $post], 'pending', 'pending');
+        $this->assertEquals([$pending], array_column($this->model->getAllHierarchical('pending'), 'id'));
+        // A historical bad parent link must never join unrelated trees or hide a comment in admin.
+        $this->pdo->exec("UPDATE comments SET parent_id = {$post} WHERE id = {$page}");
+        $this->assertSame([], $this->model->getReplies($post));
+        $roots = array_column($this->model->getAllHierarchical(), null, 'id');
+        $this->assertArrayHasKey($page, $roots);
+        $this->assertNull($roots[$page]['parent_author_name']);
+        $this->pdo->exec("UPDATE comments SET parent_id = {$pending} WHERE id = {$post}");
+        $this->assertCount(3, $this->model->getAllHierarchical());
+    }
+}

--- a/tests/Unit/CommentAjaxIsolationTest.php
+++ b/tests/Unit/CommentAjaxIsolationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Controllers\Frontend\CommentController;
+use App\Models\Comments;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CommentAjaxIsolationTest extends TestCase
+{
+    public static function requests(): array
+    {
+        return [
+            [['post_id' => '5', 'page_id' => ''], 'article', 2],
+            [['page_id' => '5', 'post_id' => ''], 'page', 1],
+            [['page_id' => '5', 'post_id' => '5'], null, 0],
+            [['page_id' => ['5']], null, 0],
+        ];
+    }
+
+    /** @dataProvider requests */
+    public function testAjaxUsesTheRequestedContentType(array $query, ?string $expected, int $total): void
+    {
+        require dirname(__DIR__) . '/Fixtures/comment_request_input.php';
+        require_once dirname(__DIR__, 2) . '/database/migrations/2026_09_06_000001_separate_comment_content_references.php';
+        $pdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY)');
+        $pdo->exec('CREATE TABLE pages (id INTEGER PRIMARY KEY)');
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, display_name TEXT)');
+        $pdo->exec('CREATE TABLE comments (id INTEGER PRIMARY KEY AUTOINCREMENT, post_id INTEGER NOT NULL,
+            content TEXT, status TEXT, parent_id INTEGER, user_id INTEGER, created_at TEXT)');
+        $pdo->exec('INSERT INTO posts VALUES (5)');
+        $pdo->exec('INSERT INTO pages VALUES (5)');
+        (new \SeparateCommentContentReferences($pdo))->up();
+        $pdo->exec("INSERT INTO comments (post_id, page_id, content, status) VALUES
+            (5, NULL, 'article', 'approved'), (5, NULL, 'article', 'approved'), (NULL, 5, 'page', 'approved')");
+        $model = $this->getMockBuilder(Comments::class)->setConstructorArgs([$pdo])
+            ->onlyMethods(['areCommentsEnabledForPost', 'areCommentsEnabledForPage'])->getMock();
+        $model->method('areCommentsEnabledForPost')->willReturn(true);
+        $model->method('areCommentsEnabledForPage')->willReturn(true);
+        $class = new \ReflectionClass(CommentController::class);
+        $controller = $class->newInstanceWithoutConstructor();
+        $property = $class->getProperty('commentModel');
+        $property->setAccessible(true);
+        $property->setValue($controller, $model);
+        $_GET = $query;
+        ob_start();
+        try {
+            $controller->getCommentsAction();
+            $response = json_decode(ob_get_contents(), true, 512, JSON_THROW_ON_ERROR);
+        } finally {
+            ob_end_clean();
+        }
+        if ($expected === null) {
+            $this->assertArrayHasKey('error', $response);
+        } else {
+            $this->assertSame($total, $response['total']);
+            $this->assertCount($total, $response['comments']);
+            $this->assertSame([$expected], array_values(array_unique(array_column($response['comments'], 'content'))));
+        }
+    }
+}

--- a/tests/Unit/CommentTargetInputTest.php
+++ b/tests/Unit/CommentTargetInputTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Controllers\Frontend\CommentController;
+use PHPUnit\Framework\TestCase;
+
+class CommentTargetInputTest extends TestCase
+{
+    public static function targets(): array
+    {
+        return [
+            'article form with blank page field' => ['5', '', ['post_id' => 5]],
+            'page form with blank article field' => ['', '5', ['page_id' => 5]],
+            'article AJAX request' => ['5', null, ['post_id' => 5]],
+            'page AJAX request' => [null, '5', ['page_id' => 5]],
+            'both targets' => ['5', '5', null],
+            'missing targets' => [null, null, null],
+            'empty form' => ['', '', null],
+            'negative article' => ['-5', null, null],
+            'zero page' => [null, '0', null],
+            'array article' => [['5'], null, null],
+            'malformed other field' => ['5', 'invalid', null],
+            'filter rejected an array' => [false, '5', null],
+        ];
+    }
+
+    /** @dataProvider targets */
+    public function testOnlyOnePositiveTargetIsAccepted($post, $page, $expected): void
+    {
+        $class = new \ReflectionClass(CommentController::class);
+        $controller = $class->newInstanceWithoutConstructor();
+        $method = $class->getMethod('parseContentTarget');
+        $method->setAccessible(true);
+        $this->assertSame($expected, $method->invoke($controller, $post, $page));
+    }
+}


### PR DESCRIPTION
## Problema

Un articolo e una pagina con lo stesso ID numerico condividono commenti e conteggi, poiché `comments.post_id` non distingue il contenuto di destinazione.

## Modifiche

- Aggiunge una migrazione che separa `post_id` e `page_id`, con `legacy_post_id` per record ambigui o orfani da verificare manualmente.
- Isola letture, conteggi, risposte, API AJAX e invio frontend per tipo di contenuto.
- Verifica che una risposta appartenga allo stesso articolo o pagina del commento padre.
- Aggiunge vincoli e indici per SQLite e MySQL; MySQL usa trigger per l'esclusività dei riferimenti, compatibili con le azioni `ON DELETE CASCADE`.
- Mostra i commenti storici irrisolti nell'admin senza renderli pubblici o approvabili.
- Documenta aggiornamento, rollback tramite backup e procedura di riconciliazione dei dati ambigui.

## Verifica

- `40` test dedicati, `330` asserzioni: SQLite e MySQL, con e senza i vincoli del precedente schema.
- Suite completa: `446` test, `888` asserzioni, superata con `57` skip previsti dall'ambiente.
- Rendering verificato per entrambe le viste admin dei commenti irrisolti.

Closes #40
